### PR TITLE
correct naming normalization problems

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/aws/aws-service-operator-k8s
 go 1.14
 
 require (
+	github.com/dlclark/regexp2 v1.2.0
 	// pin to v0.1.1 due to release problem with v0.1.2
 	github.com/gertd/go-pluralize v0.1.1
 	github.com/getkin/kin-openapi v0.3.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/spf13/cobra v0.0.7
+	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,9 +15,12 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
+github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gertd/go-pluralize v0.1.1 h1:fQhql/WRRwr4TVp+TCw12s2esCacvEVBdkTUUwNqF/Q=
 github.com/gertd/go-pluralize v0.1.1/go.mod h1:t5DfHcumb6m0RqyVJDrDLEzL2AGeaiqUXIcDNwLaeAs=
@@ -63,6 +66,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -90,6 +94,7 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -16,44 +16,96 @@ package names
 import (
 	"strings"
 
+	regexp "github.com/dlclark/regexp2" // for negative lookahead support
 	"github.com/iancoleman/strcase"
 )
 
+type initialismTranslator struct {
+	// CamelCased initialism, e.g. Tls
+	camel string
+	// Uppercase representation of the initialism
+	upper string
+	// Lowercase representation of the initialism
+	lower string
+	// Regular expression matching the initialism within a subject string.
+	// Usually nil, unless the camel-cased initialism is a series of characters
+	// that is commonly confused with a longer form of the initialism (e.g. for
+	// "Id", we don't want to match "Identifier")
+	re *regexp.Regexp
+}
+
 var (
-	initialisms = map[string]string{
-		"Url":   "URL",
-		"Uri":   "URI",
-		"Id":    "ID",
-		"Arn":   "ARN",
-		"Acl":   "ACL",
-		"Acp":   "ACP",
-		"Mfa":   "MFA",
-		"Api":   "API",
-		"Sse":   "SSE",
-		"Http":  "HTTP",
-		"Https": "HTTPS",
-		"Tls":   "TLS",
-		"Ssl":   "SSL",
-		"Tcp":   "TCP",
-		"Udp":   "UDP",
-		"Dns":   "DNS",
-		"Json":  "JSON",
-		"Yaml":  "YAML",
-		"Xml":   "XML",
-		"Html":  "HTML",
-		"Aws":   "AWS",
-		"Jwt":   "JWT",
-		"Vpc":   "VPC",
-		"Ec2":   "EC2",
-		"Kms":   "KMS",
-		"Sqs":   "SQS",
-		"Sdk":   "SDK",
-		"Ecr":   "ECR",
-		"Eks":   "EKS",
-		"Ebs":   "EBS",
-		"Efs":   "EFS",
-		"Waf":   "WAF",
-		"Db":    "DB",
+	// NOTE(jaypipes): these are ordered. Some things need to be processed
+	// before others. For example, we need to process "Dbi" before "Db"
+	initialisms = []initialismTranslator{
+		// Special... even though IDS is a valid initialism, in AWS APIs, the
+		// camel-cased "Ids" refers to a set of Identifiers, so the correct
+		// uppercase representation is "IDs"
+		{"Ids", "IDs", "ids", nil},
+		// Need to prevent "Identifier" from becoming "IDentifier"
+		{"Id", "ID", "id", regexp.MustCompile("Id(?!entifier)", regexp.None)},
+		// Need to prevent "DbInstance" from becoming "dbinstance" when lower
+		// prefix-converted (should be dbInstance). Amazingly, even within just
+		// the RDS API, there are fields named "DbiResourceId",
+		// "DBInstanceIdentifier" and "DbInstanceIdentifier" (note the
+		// capitalization differences). This transformer handles this
+		// problematic scenario and matches only the "Dbi" case-sensitive
+		// expression and converts it to "DBI" or "dbi" depending on whether
+		// the initialism appears at the start of the name
+		{"Dbi", "DBI", "dbi", regexp.MustCompile("Dbi", regexp.None)},
+		// Prevent "CACertificateIdentifier" from becoming
+		// "cACertificateIdentifier when lower prefix-converted (should be
+		// "caCertificateIdentifier")
+		{"CACert", "CACert", "caCert", regexp.MustCompile("CACert", regexp.None)},
+		// Prevent "MD5OfBody" from becoming "MD5OfBody" when lower
+		// prefix-converted (should be "md5OfBody")
+		{"MD5Of", "MD5Of", "md5Of", regexp.MustCompile("M[dD]5Of", regexp.None)},
+		// Easy find-and-replacements...
+		{"Acl", "ACL", "acl", nil},
+		{"Acp", "ACP", "acp", nil},
+		{"Api", "API", "api", nil},
+		{"Arn", "ARN", "arn", nil},
+		{"Asn", "ASN", "asn", nil},
+		{"Aws", "AWS", "aws", nil},
+		{"Az", "AZ", "az", nil},
+		{"Bgp", "BGP", "bgp", nil},
+		{"Cidr", "CIDR", "cidr", nil},
+		{"Db", "DB", "db", nil},
+		{"Dhcp", "DHCP", "dhcp", nil},
+		{"Dns", "DNS", "dns", nil},
+		{"Ebs", "EBS", "ebs", nil},
+		{"Ec2", "EC2", "ec2", nil},
+		{"Ecr", "ECR", "ecr", nil},
+		{"Efs", "EFS", "efs", nil},
+		{"Eks", "EKS", "eks", nil},
+		{"Fpga", "FPGA", "fpga", nil},
+		{"Html", "HTML", "xml", nil},
+		{"Http", "HTTP", "http", nil},
+		{"Https", "HTTPS", "https", nil},
+		{"Iam", "IAM", "iam", nil},
+		{"Icmp", "ICMP", "icmp", nil},
+		{"Iops", "IOPS", "iops", nil},
+		{"Ip", "IP", "ip", nil},
+		{"Json", "JSON", "json", nil},
+		{"Jwt", "JWT", "jwt", nil},
+		{"Kms", "KMS", "kms", nil},
+		{"Mfa", "MFA", "mfa", nil},
+		{"Sdk", "SDK", "sdk", nil},
+		{"Sqs", "SQS", "sns", nil},
+		{"Sse", "SSE", "sse", nil},
+		{"Ssl", "SSL", "ssl", nil},
+		{"Tcp", "TCP", "tcp", nil},
+		{"Tde", "TDE", "tde", nil},
+		{"Tls", "TLS", "tls", nil},
+		{"Udp", "UDP", "udp", nil},
+		{"Uri", "URI", "uri", nil},
+		{"Url", "URL", "url", nil},
+		{"Vpc", "VPC", "vpc", nil},
+		{"Vpn", "VPN", "vpn", nil},
+		{"Vgw", "VGW", "vgw", nil},
+		{"Waf", "WAF", "waf", nil},
+		{"Xml", "XML", "xml", nil},
+		{"Yaml", "YAML", "yaml", nil},
 	}
 )
 
@@ -69,44 +121,104 @@ func New(original string) Names {
 		Original:     original,
 		GoUnexported: goName(original, true),
 		GoExported:   goName(original, false),
-		JSON:         jsonName(original),
 	}
 }
 
-func goName(original string, lower bool) string {
-	return normalizeInitialisms(strcase.ToCamel(original), lower)
-}
-
-func jsonName(original string) string {
-	return strcase.ToLowerCamel(normalizeInitialisms(original, true))
+func goName(original string, lowerFirst bool) (result string) {
+	result = original
+	if !lowerFirst {
+		result = strcase.ToCamel(result)
+	}
+	result, err := normalizeInitialisms(result, lowerFirst)
+	if err != nil {
+		panic(err)
+	}
+	if lowerFirst {
+		result, err = normalizeInitialisms(strcase.ToLowerCamel(result), lowerFirst)
+	}
+	return
 }
 
 // normalizeInitialisms takes a subject string and adapts the string according
 // to the Go best practice naming convention for initialisms.
 //
+// Examples:
+//
+//  original   | lowerFirst | output
+// ------------+ ---------- + -------------------------
+// Identifier  | true       | Identifier
+// Identifier  | false      | Identifier
+// Id          | true       | id
+// Id          | false      | ID
+// SSEKMSKeyId | true       | sseKMSKeyID
+// SSEKMSKeyId | false      | SSEKMSKeyID
+// RoleArn     | true       | roleARN
+// RoleArn     | false      | RoleARN
+//
 // See: https://github.com/golang/go/wiki/CodeReviewComments#initialisms
-func normalizeInitialisms(original string, lower bool) string {
-	for from, to := range initialisms {
-		x := strings.Index(original, from)
-		switch x {
-		case -1:
+func normalizeInitialisms(original string, lowerFirst bool) (result string, err error) {
+	result = original
+	for _, initTrx := range initialisms {
+		if initTrx.re == nil {
 			// if we need to lowercase initialisms, check to see if the
 			// initialism's capitalized form starts the string, and if so,
 			// lowercase it. For example, if we get original == SSEKMSKeyId and
 			// we pass lower == true, we want to return sseKMSKeyID
-			if lower && strings.Index(original, to) == 0 {
-				original = strings.Replace(original, to, strings.ToLower(to), 1)
+			if lowerFirst && strings.Index(result, initTrx.upper) == 0 {
+				result = strings.Replace(result, initTrx.upper, initTrx.lower, 1)
 			}
-			continue
-		case 0:
-			if !lower {
-				original = strings.Replace(original, from, to, -1)
-			} else {
-				original = strings.Replace(original, from, strings.ToLower(to), -1)
+			// Replace CamelCased initialisms with the uppercase representation
+			// of the initialism EXCEPT when the CamelCased initialism appears
+			// at the start of the original string and we've passed a true
+			// lower parameter, in which case we lowercase just the first
+			// occurrence of the CamelCased initialism
+			pos := strings.Index(result, initTrx.camel)
+			switch pos {
+			case -1:
+				continue
+			case 0:
+				if lowerFirst {
+					result = strings.Replace(result, initTrx.camel, initTrx.lower, 1)
+				}
+				result = strings.Replace(result, initTrx.camel, initTrx.upper, -1)
+			default:
+				result = strings.Replace(result, initTrx.camel, initTrx.upper, -1)
 			}
-		default:
-			original = strings.Replace(original, from, to, -1)
+		} else {
+			match, err := initTrx.re.FindStringMatch(result)
+			if err != nil {
+				return "", err
+			}
+			if match == nil {
+				continue
+			}
+			startFrom := match.Group.Capture.Index
+			if lowerFirst {
+				if startFrom == 0 {
+					// The matched string appears at the start of the string --
+					// e.g. IdFirstElementId. In this case, if we've asked to lower
+					// the output, we need to lower only the first occurrence of
+					// the matched expression, not all of it -- e.g.
+					// idFirstElementID
+					result, err = initTrx.re.Replace(result, initTrx.lower, 0, 1)
+					if err != nil {
+						return "", err
+					}
+					match, err = initTrx.re.FindNextMatch(match)
+					if err != nil {
+						return "", nil
+					}
+					if match == nil {
+						continue
+					}
+					startFrom = match.Group.Capture.Index
+				}
+			}
+			result, err = initTrx.re.Replace(result, initTrx.upper, startFrom, -1)
+			if err != nil {
+				return "", err
+			}
 		}
 	}
-	return original
+	return result, nil
 }

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -1,0 +1,53 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package names_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-service-operator-k8s/pkg/names"
+)
+
+func TestNames(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		original         string
+		expectExported   string
+		expectUnexported string
+	}{
+		{"Identifier", "Identifier", "identifier"},
+		{"Id", "ID", "id"},
+		{"ID", "ID", "id"},
+		{"KeyIdentifier", "KeyIdentifier", "keyIdentifier"},
+		{"KeyId", "KeyID", "keyID"},
+		{"KeyID", "KeyID", "keyID"},
+		{"SSEKMSKeyID", "SSEKMSKeyID", "sseKMSKeyID"},
+		{"DbiResourceId", "DBIResourceID", "dbiResourceID"},
+		{"DbInstanceId", "DBInstanceID", "dbInstanceID"},
+		{"DBInstanceId", "DBInstanceID", "dbInstanceID"},
+		{"DBInstanceID", "DBInstanceID", "dbInstanceID"},
+		{"DBInstanceIdentifier", "DBInstanceIdentifier", "dbInstanceIdentifier"},
+	}
+	for _, tc := range testCases {
+		n := names.New(tc.original)
+		msg := fmt.Sprintf("for original %s expected exported name of %s but got %s", tc.original, tc.expectExported, n.GoExported)
+		assert.Equal(tc.expectExported, n.GoExported, msg)
+		msg = fmt.Sprintf("for original %s expected unexported name of %s but got %s", tc.original, tc.expectUnexported, n.GoUnexported)
+		assert.Equal(tc.expectUnexported, n.GoUnexported, msg)
+	}
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-service-operator-k8s/pkg/names"
 	"github.com/gertd/go-pluralize"
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -50,6 +51,7 @@ type ResourceOps struct {
 
 type Resource struct {
 	api         *openapi3.Swagger
+	Names       names.Names
 	Kind        string
 	Plural      string
 	Ops         ResourceOps
@@ -188,10 +190,15 @@ func ResourcesFromAPI(api *openapi3.Swagger) ([]*Resource, error) {
 			continue
 		}
 
+		names := names.New(singularName)
+		kind := names.GoExported
+		plural := pluralize.Plural(kind)
+
 		resource := &Resource{
 			api:    api,
-			Kind:   singularName,
-			Plural: pluralName,
+			Names:  names,
+			Kind:   kind,
+			Plural: plural,
 			Ops:    ResourceOps{createOp},
 		}
 		resource.loadAttrs()

--- a/pkg/resource/type_def.go
+++ b/pkg/resource/type_def.go
@@ -17,12 +17,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-service-operator-k8s/pkg/names"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/iancoleman/strcase"
 )
 
 type TypeDef struct {
-	Name  string
+	Names names.Names
 	Attrs map[string]*Attr
 }
 
@@ -125,7 +126,7 @@ func TypeDefsFromAPI(
 			continue
 		}
 		tdefs = append(tdefs, &TypeDef{
-			Name:  schemaName,
+			Names: names.New(schemaName),
 			Attrs: attrs,
 		})
 	}

--- a/templates/enum_def.go.tpl
+++ b/templates/enum_def.go.tpl
@@ -3,7 +3,7 @@ type {{ .Names.GoExported }} {{ .GoType }}
 
 const (
 {{- range $val := .Values }}
-	{{ $.Names.GoExported }}_{{ $val }} {{ $.GoType }} = {{ if eq $.GoType "string" }}"{{ end }}{{ $val }}{{ if eq $.GoType "string" }}"{{ end }}
+	{{ $.Names.GoExported }}_{{ $val.Clean }} {{ $.GoType }} = {{ if eq $.GoType "string" }}"{{ end }}{{ $val.Original }}{{ if eq $.GoType "string" }}"{{ end }}
 {{- end }}
 )
 {{- end -}}

--- a/templates/resource.go.tpl
+++ b/templates/resource.go.tpl
@@ -16,14 +16,14 @@ type {{ .Resource.Kind }}Spec struct {
 	// already exist in the backend AWS service API.
 	ARN *string `json:"arn,omitempty"`
 	{{- range $attrName, $attr := .Resource.SpecAttrs }}
-	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.JSON }},omitempty" aws:"{{ $attr.Names.Original }}"`
+	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.GoUnexported }},omitempty" aws:"{{ $attr.Names.Original }}"`
 {{- end }}
 }
 
 // {{ .Resource.Kind }}Status defines the observed state of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}Status struct {
 	{{- range $attrName, $attr := .Resource.StatusAttrs }}
-	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.JSON }},omitempty" aws:"{{ $attr.Names.Original }}"`
+	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.GoUnexported }},omitempty" aws:"{{ $attr.Names.Original }}"`
 {{- end }}
 }
 

--- a/templates/type_def.go.tpl
+++ b/templates/type_def.go.tpl
@@ -1,7 +1,7 @@
 {{- define "type_def" -}}
-type {{ .Name }} struct {
+type {{ .Names.GoExported }} struct `aws:"{{ .Names.Original }}"` {
 {{- range $attrName, $attr := .Attrs }}
-	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.JSON }},omitempty" aws:"{{ $attr.Names.Original }}"`
+	{{ $attr.Names.GoExported }} {{ $attr.GoType }} `json:"{{ $attr.Names.GoUnexported }},omitempty" aws:"{{ $attr.Names.Original }}"`
 {{- end }}
 }
 {{- end -}}


### PR DESCRIPTION
In generating type definitions for various service APIs, I noticed the
normalization of names for fields and structs had a few errors. For
example, in the RDS API, the following are all field names:

* DBInstanceIdentifier
* DbInstanceIdentifier
* DBInstanceId
* DbiResourceId

Pay attention to the slight case differences and the use of the word
"Identifier" and "Id" or "ID"...

This commit adds fixes for incorrect normalization that was, for
example, outputting "DbInstanceIDentifier" or "dBiResourceID".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
