### PR TITLE
fixes for enum and type definition generation

### DIFF
--- a/pkg/model/enum_def.go
+++ b/pkg/model/enum_def.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/aws/aws-service-operator-k8s/pkg/names"
 )
@@ -24,13 +25,27 @@ type EnumValue struct {
 	Clean    string
 }
 
+// EnumDef is the definition of an enumeration type for a field present in
+// either a CRD or a TypeDef
 type EnumDef struct {
 	Names  names.Names
 	GoType string
 	Values []EnumValue
 }
 
-func NewEnumVal(orig string) EnumValue {
+func NewEnumDef(names names.Names, goType string, values []interface{}) (*EnumDef, error) {
+	enumVals := make([]EnumValue, len(values))
+	for x, item := range values {
+		strVal, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %v to string", item)
+		}
+		enumVals[x] = newEnumVal(strVal)
+	}
+	return &EnumDef{names, goType, enumVals}, nil
+}
+
+func newEnumVal(orig string) EnumValue {
 	// Convert values like "m5.xlarge" into "m5_xlarge"
 	cleaner := func(r rune) rune {
 		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {

--- a/pkg/schema/attr.go
+++ b/pkg/schema/attr.go
@@ -46,7 +46,7 @@ func (h *Helper) getAttrsFromRequestSchemaRef(
 	for propName, propSchemaRef := range schema.Properties {
 		propSchema := h.getSchemaFromSchemaRef(propSchemaRef)
 		names := names.New(propName)
-		goType := h.getGoTypeFromSchema(names.GoExported, schema)
+		goType := h.getGoTypeFromSchema(propName, propSchema)
 		attrs = append(attrs, model.NewAttr(names, goType, propSchema))
 	}
 	return attrs
@@ -90,7 +90,7 @@ func (h *Helper) getAttrsFromResponseSchemaRef(
 	for propName, propSchemaRef := range schema.Properties {
 		propSchema := h.getSchemaFromSchemaRef(propSchemaRef)
 		names := names.New(propName)
-		goType := h.getGoTypeFromSchema(names.GoExported, schema)
+		goType := h.getGoTypeFromSchema(names.GoExported, propSchema)
 		attrs = append(attrs, model.NewAttr(names, goType, propSchema))
 	}
 	return attrs

--- a/pkg/schema/enum_def.go
+++ b/pkg/schema/enum_def.go
@@ -43,19 +43,11 @@ func (h *Helper) GetEnumDefs() ([]*model.EnumDef, error) {
 		default:
 			return nil, fmt.Errorf("cannot determine go type from enum schema type %s", schema.Type)
 		}
-		vals := make([]model.EnumValue, len(schema.Enum))
-		for x, item := range schema.Enum {
-			strVal, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf("cannot convert %v to string", item)
-			}
-			vals[x] = model.NewEnumVal(strVal)
+		edef, err := model.NewEnumDef(names.New(schemaName), goType, schema.Enum)
+		if err != nil {
+			return nil, err
 		}
-		edefs = append(edefs, &model.EnumDef{
-			Names:  names.New(schemaName),
-			GoType: goType,
-			Values: vals,
-		})
+		edefs = append(edefs, edef)
 	}
 	return edefs, nil
 }

--- a/pkg/schema/util.go
+++ b/pkg/schema/util.go
@@ -14,9 +14,11 @@
 package schema
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/gertd/go-pluralize"
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -55,22 +57,28 @@ func (h *Helper) getGoTypeFromSchema(
 	case "boolean":
 		return "bool"
 	case "string":
+		if schema.Format == "byte" {
+			return "[]byte"
+		}
 		return "string"
 	case "number":
-		if schema.Format != "" {
-			switch schema.Format {
-			case "int64":
-				return "int64"
-			case "float64":
-				return "float64"
-			}
+		if schema.Format == "float64" {
+			return "float64"
 		}
 		return "int64"
 	case "integer":
 		return "int64"
 	case "array":
 		itemsSchema := h.getSchemaFromSchemaRef(schema.Items)
-		itemType := h.getGoTypeFromSchema(schemaName, itemsSchema)
+		var itemType string
+		if itemsSchema.Type == "object" {
+			itemType = h.deduceArrayOfObjectsType(schemaName, itemsSchema)
+			if itemType == "" {
+				itemType = "!!! UNKNOWN ARRAY OBJECT TYPE !!!"
+			}
+		} else {
+			itemType = h.getGoTypeFromSchema(schemaName, itemsSchema)
+		}
 		return "[]" + itemType
 	case "object":
 		if schema.AdditionalPropertiesAllowed != nil && *schema.AdditionalPropertiesAllowed {
@@ -79,6 +87,73 @@ func (h *Helper) getGoTypeFromSchema(
 		return "*" + schemaName
 	}
 	return "!!! UNKNOWN !!!"
+}
+
+// Some shapes in AWS service APIs are arrays of unnamed objects. A good
+// example of this is the SNS API's TagList shape, transformed into the
+// following JSONSchema:
+//
+//    TagList:
+//      items:
+//        properties:
+//          Key:
+//            $ref: '#/components/schemas/TagKey'
+//          Value:
+//            $ref: '#/components/schemas/TagValue'
+//        required:
+//        - Key
+//        - Value
+//        type: object
+//      type: array
+//    Tag:
+//      properties:
+//        Key:
+//          $ref: '#/components/schemas/TagKey'
+//        Value:
+//          $ref: '#/components/schemas/TagValue'
+//      required:
+//      - Key
+//      - Value
+//      type: object
+//
+// We need to convert a reference to the TagList schema (i.e.
+// #/components/schemas/TagList) into the following Go type definition:
+//
+//   []*Tag
+//
+// Because we don't know that the TagList items are actually Tag objects, we
+// need to try and deduce this information. We first examine the name of the
+// array type and see if there is an object type with the same name without the
+// "List" or "s" or "Set" suffixes. We then check to see if the schema of the
+// found object type is identical to the schema of the items in the array type.
+func (h *Helper) deduceArrayOfObjectsType(
+	arrayTypeName string,
+	objectTypeSchema *openapi3.Schema,
+) string {
+	guessObjectTypeName := ""
+	if strings.HasSuffix(arrayTypeName, "List") {
+		guessObjectTypeName = strings.TrimSuffix(arrayTypeName, "List")
+	} else if strings.HasSuffix(arrayTypeName, "Set") {
+
+	} else {
+		// Fall back to determining if the array type name is a plural
+		pluralize := pluralize.NewClient()
+		if pluralize.IsPlural(arrayTypeName) {
+			guessObjectTypeName = pluralize.Singular(arrayTypeName)
+		}
+	}
+	if guessObjectTypeName != "" {
+		// Check to see if there is a schema matching the guessed object type
+		// name and if so, return that schema name as the target object type
+		fmt.Printf("Looking up %s\n", guessObjectTypeName)
+		_, found := h.api.Components.Schemas[guessObjectTypeName]
+		if found {
+			return "*" + guessObjectTypeName
+		}
+		// TODO(jaypipes): Look through all schemas and try to match on known
+		// properties?
+	}
+	return ""
 }
 
 // getSchemaFromSchemaRef returns an openapi3.Schema given a SchemaRef
@@ -91,7 +166,6 @@ func (h *Helper) getSchemaFromSchemaRef(
 			schema, found := h.api.Components.Schemas[refSchemaID]
 			if found {
 				return schema.Value
-
 			}
 		}
 	} else {

--- a/templates/enum_def.go.tpl
+++ b/templates/enum_def.go.tpl
@@ -3,7 +3,7 @@ type {{ .Names.GoExported }} {{ .GoType }}
 
 const (
 {{- range $val := .Values }}
-	{{ $.Names.GoExported }}_{{ $val.Clean }} {{ $.GoType }} = {{ if eq $.GoType "string" }}"{{ end }}{{ $val.Original }}{{ if eq $.GoType "string" }}"{{ end }}
+	{{ $.Names.GoExported }}_{{ $val.Clean }} {{ $.Names.GoExported }} = {{ if eq $.GoType "string" }}"{{ end }}{{ $val.Original }}{{ if eq $.GoType "string" }}"{{ end }}
 {{- end }}
 )
 {{- end -}}


### PR DESCRIPTION
Two commits with fixes for some errors encountered during type and enum definition generation. First commit corrects the Go type output for enum definitions. Second commit corrects improper array of object Go type output and where I was passing the wrong Schema object for certain object-like attributes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
