### PR TITLE
start adding schema-parsing unit tests

### DIFF
--- a/pkg/schema/crd_test.go
+++ b/pkg/schema/crd_test.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package schema_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/aws-service-operator-k8s/pkg/model"
+	"github.com/aws/aws-service-operator-k8s/pkg/schema"
+)
+
+func loadSwagger(t *testing.T, yamlFile string) *openapi3.Swagger {
+	path := filepath.Join("testdata", yamlFile)
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var jsonb []byte
+
+	if jsonb, err = yaml.YAMLToJSON(b); err != nil {
+		t.Fatal(err)
+	}
+
+	api, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(jsonb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return api
+}
+
+func attrExportedNames(attrs map[string]*model.Attr) []string {
+	res := []string{}
+	for _, attr := range attrs {
+		res = append(res, attr.Names.GoExported)
+	}
+	sort.Strings(res)
+	return res
+}
+
+func TestGetCRDs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	api := loadSwagger(t, "topic-api.yaml")
+	sh := schema.NewHelper(api)
+
+	crds, err := sh.GetCRDs()
+	require.Nil(err)
+
+	assert.Equal(1, len(crds))
+
+	topicCRD := crds[0]
+
+	assert.Equal("Topic", topicCRD.Names.GoExported)
+	assert.Equal("topic", topicCRD.Names.GoUnexported)
+
+	specAttrs := topicCRD.SpecAttrs
+	statusAttrs := topicCRD.StatusAttrs
+
+	assert.Equal(3, len(specAttrs))
+	expSpecAttrExported := []string{
+		"Attributes",
+		"Name",
+		"Tags",
+	}
+	assert.Equal(expSpecAttrExported, attrExportedNames(specAttrs))
+	assert.Equal(1, len(statusAttrs))
+	expStatusAttrExported := []string{
+		"TopicARN",
+	}
+	assert.Equal(expStatusAttrExported, attrExportedNames(statusAttrs))
+}

--- a/pkg/schema/testdata/topic-api.yaml
+++ b/pkg/schema/testdata/topic-api.yaml
@@ -1,0 +1,295 @@
+components:
+  schemas:
+    CreateTopicInput:
+      properties:
+        Attributes:
+          $ref: '#/components/schemas/TopicAttributesMap'
+        Name:
+          $ref: '#/components/schemas/topicName'
+        Tags:
+          $ref: '#/components/schemas/TagList'
+      required:
+      - Name
+      type: object
+    CreateTopicResponse:
+      properties:
+        TopicArn:
+          $ref: '#/components/schemas/topicARN'
+      type: object
+    DeleteTopicInput:
+      properties:
+        TopicArn:
+          $ref: '#/components/schemas/topicARN'
+      required:
+      - TopicArn
+      type: object
+    GetTopicAttributesInput:
+      properties:
+        TopicArn:
+          $ref: '#/components/schemas/topicARN'
+      required:
+      - TopicArn
+      type: object
+    GetTopicAttributesResponse:
+      properties:
+        Attributes:
+          $ref: '#/components/schemas/TopicAttributesMap'
+      type: object
+    InternalErrorException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    InvalidParameterException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    InvalidSecurityException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    ListTopicsInput:
+      properties:
+        NextToken:
+          $ref: '#/components/schemas/nextToken'
+      type: object
+    ListTopicsResponse:
+      properties:
+        NextToken:
+          $ref: '#/components/schemas/nextToken'
+        Topics:
+          $ref: '#/components/schemas/TopicsList'
+      type: object
+    MapStringToString:
+      additionalProperties: true
+      type: object
+    NotFoundException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    ResourceNotFoundException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    SetTopicAttributesInput:
+      properties:
+        AttributeName:
+          $ref: '#/components/schemas/attributeName'
+        AttributeValue:
+          $ref: '#/components/schemas/attributeValue'
+        TopicArn:
+          $ref: '#/components/schemas/topicARN'
+      required:
+      - TopicArn
+      - AttributeName
+      type: object
+    StaleTagException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    String:
+      type: string
+    Tag:
+      properties:
+        Key:
+          $ref: '#/components/schemas/TagKey'
+        Value:
+          $ref: '#/components/schemas/TagValue'
+      required:
+      - Key
+      - Value
+      type: object
+    TagKey:
+      maxLength: 128
+      minLength: 1
+      type: string
+    TagLimitExceededException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    TagList:
+      items:
+        properties:
+          Key:
+            $ref: '#/components/schemas/TagKey'
+          Value:
+            $ref: '#/components/schemas/TagValue'
+        required:
+        - Key
+        - Value
+        type: object
+      type: array
+    TagPolicyException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    TagValue:
+      maxLength: 256
+      type: string
+    Topic:
+      properties:
+        TopicArn:
+          $ref: '#/components/schemas/topicARN'
+      type: object
+    TopicAttributesMap:
+      additionalProperties: true
+      type: object
+    TopicLimitExceededException:
+      properties:
+        message:
+          $ref: '#/components/schemas/string'
+      type: object
+      x-aws-api-exception: true
+    TopicsList:
+      items:
+        properties:
+          TopicArn:
+            $ref: '#/components/schemas/topicARN'
+        type: object
+      type: array
+    attributeName:
+      type: string
+    attributeValue:
+      type: string
+    nextToken:
+      type: string
+    string:
+      type: string
+    topicARN:
+      type: string
+    topicName:
+      type: string
+info:
+  description: example API that just operates on SNS-like Topic resources
+  title: example Topic API
+  version: "9999-99-99"
+  x-aws-api-alias: topic
+  x-aws-api-protocol: query
+openapi: 3.0.0
+paths:
+  /#CreateTopic:
+    post:
+      operationId: CreateTopic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTopicInput'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTopicResponse'
+        "400":
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/InvalidParameterException'
+                - $ref: '#/components/schemas/TagLimitExceededException'
+                - $ref: '#/components/schemas/StaleTagException'
+                - $ref: '#/components/schemas/TagPolicyException'
+        "403":
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/TopicLimitExceededException'
+                - $ref: '#/components/schemas/InvalidSecurityException'
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorException'
+  /#DeleteTopic:
+    post:
+      operationId: DeleteTopic
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteTopicInput'
+      responses: null
+  /#GetTopicAttributes:
+    post:
+      operationId: GetTopicAttributes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetTopicAttributesInput'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTopicAttributesResponse'
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterException'
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidSecurityException'
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundException'
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorException'
+  /#ListTopics:
+    post:
+      operationId: ListTopics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListTopicsInput'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTopicsResponse'
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidParameterException'
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalErrorException'
+  /#SetTopicAttributes:
+    post:
+      operationId: SetTopicAttributes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetTopicAttributesInput'
+      responses: null


### PR DESCRIPTION
Adds simple unit test for the schema helper's GetCRDS() method using a
simplified SNS-like API fixture.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
