### PR TITLE
Make sure that rmCache is initialized

### DIFF
--- a/services/bookstore/pkg/resource/book/descriptor.go
+++ b/services/bookstore/pkg/resource/book/descriptor.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package resource
+package book
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/services/bookstore/pkg/resource/book/identifiers.go
+++ b/services/bookstore/pkg/resource/book/identifiers.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package resource
+package book
 
 import (
 	ackv1alpha1 "github.com/aws/aws-service-operator-k8s/apis/core/v1alpha1"

--- a/services/bookstore/pkg/resource/book/manager.go
+++ b/services/bookstore/pkg/resource/book/manager.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package resource
+package book
 
 import (
 	"context"

--- a/services/bookstore/pkg/resource/book/manager_factory.go
+++ b/services/bookstore/pkg/resource/book/manager_factory.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package resource
+package book
 
 import (
 	"sync"
@@ -66,6 +66,12 @@ func (f *bookResourceManagerFactory) ManagerFor(
 	return rm, nil
 }
 
+func newBookResourceManagerFactory() *bookResourceManagerFactory {
+	return &bookResourceManagerFactory{
+		rmCache: map[ackv1alpha1.AWSAccountID]*bookResourceManager{},
+	}
+}
+
 func init() {
-	svcresource.RegisterManagerFactory(&bookResourceManagerFactory{})
+	svcresource.RegisterManagerFactory(newBookResourceManagerFactory())
 }

--- a/services/bookstore/pkg/resource/book/manager_factory_test.go
+++ b/services/bookstore/pkg/resource/book/manager_factory_test.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package book_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ackv1alpha1 "github.com/aws/aws-service-operator-k8s/apis/core/v1alpha1"
+	acktypes "github.com/aws/aws-service-operator-k8s/pkg/types"
+
+	resource "github.com/aws/aws-service-operator-k8s/services/bookstore/pkg/resource"
+	// The book package's init() registers the book resource manager factory
+	// with the resource package's registry
+	_ "github.com/aws/aws-service-operator-k8s/services/bookstore/pkg/resource/book"
+)
+
+func TestManagerFor(t *testing.T) {
+	require := require.New(t)
+
+	rmfs := resource.GetManagerFactories()
+	require.NotEmpty(rmfs)
+
+	var bookRMF acktypes.AWSResourceManagerFactory
+	for _, rmf := range rmfs {
+		if rmf.ResourceDescriptor().GroupKind().String() == "Book.bookstore.services.k8s.aws" {
+			bookRMF = rmf
+		}
+	}
+
+	require.NotNil(bookRMF)
+
+	acctID := ackv1alpha1.AWSAccountID("aws-account-id")
+	bookRM, err := bookRMF.ManagerFor(acctID)
+	require.Nil(err)
+	require.NotNil(bookRM)
+	require.Implements((*acktypes.AWSResourceManager)(nil), bookRM)
+
+	// The resource manager factory should keep a cache of resource manager
+	// objects, keyed by account ID.
+	otherBookRM, err := bookRMF.ManagerFor(acctID)
+	require.Nil(err)
+	require.Exactly(bookRM, otherBookRM)
+}

--- a/services/bookstore/pkg/resource/book/resource.go
+++ b/services/bookstore/pkg/resource/book/resource.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package resource
+package book
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Varun noticed in testing that the ManagerFor() method of the
bookResourceManagerFactory struct was throwing a nil pointer exception
due to the rmCache field not being properly initialized to a valid map.
This patch fixes that problem by ensuring that the resource manager
factory registered in init() has a properly initialized rmCache.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
