### PR TITLE
Using helm to initialize service controllers for integration-test.

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -28,3 +28,12 @@ function display_timelines() {
     echo "TIMELINE: Conformance tests took $CONFORMANCE_DURATION seconds."
     echo "TIMELINE: Down processes took $DOWN_DURATION seconds."
 }
+
+should_execute() {
+  if [[ "$TEST_PASS" -ne 0 ]]; then
+    echo "NOTE: Skipping operation '$1'. Test is already marked as failed."
+    return 1
+  else
+    return 0
+  fi
+}

--- a/scripts/lib/helm.sh
+++ b/scripts/lib/helm.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+add_helm_repo() {
+   if ! should_execute add_helm_repo; then
+     return 1
+   fi
+
+   # add the helm repository containing charts for starting AWS service controllers
+   if ! helm repo add "$HELM_LOCAL_REPO_NAME" "$HELM_REPO_SOURCE" > /dev/null 2>&1; then
+     echo "Unable to add local helm repo from '$HELM_REPO_SOURCE'"
+     TEST_PASS=1
+     return 1
+   fi
+
+  #list the charts in the the local repo
+  echo "Validating the presence of '$HELM_REPO_CHART_NAME' in local repo '$HELM_LOCAL_REPO_NAME' "
+  helm_repo_output_lines=$(helm search repo "$HELM_LOCAL_REPO_NAME" | grep "$HELM_REPO_CHART_NAME" | wc -l)
+  if [[ "$helm_repo_output_lines" -gt 0 ]]; then
+    echo "'$HELM_REPO_CHART_NAME' chart is present in local helm repo '$HELM_LOCAL_REPO_NAME'"
+  else
+    echo "'$HELM_REPO_CHART_NAME' chart is NOT present in local helm repo '$HELM_LOCAL_REPO_NAME'."
+    TEST_PASS=1
+  fi
+}
+
+install_helm() {
+  # install helm in /tmp directory
+  pushd /tmp
+  # clone the source
+  git clone https://github.com/helm/helm.git
+  # build the source and move to bin
+  cd helm; make
+  #Update the path
+  export PATH=/tmp/helm/bin/:$PATH
+  popd
+}
+
+install_helm_chart() {
+  if ! should_execute install_helm_chart; then
+     return 1
+  fi
+
+  echo "Installing helm chart '$HELM_LOCAL_CHART_NAME' with image tag suffix:base"
+  local __image_tag_suffix="$1"
+
+  #install the helm chart
+   if ! helm install "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set testTag="$__image_tag_suffix" > /dev/null 2>&1; then
+     echo "Failed to install helm chart '$HELM_LOCAL_CHART_NAME'."
+     TEST_PASS=1
+  fi
+}
+
+uninstall_helm_chart() {
+  #uninstall the helm chart
+ if ! helm uninstall "$HELM_LOCAL_CHART_NAME" > /dev/null 2>&1 ; then
+    echo "Failed to uninstall helm chart '$HELM_LOCAL_CHART_NAME'"
+    # No need to mark the test as failed if controllers cannot be uninstalled due to some reason.
+  fi
+}
+
+
+upgrade_helm_chart() {
+  if ! should_execute upgrade_helm_chart; then
+     return 1
+  fi
+
+  echo "Upgrading helm chart '$HELM_LOCAL_CHART_NAME' with image tag suffix:test"
+  local __image_tag_suffix="$1"
+
+  #install the helm chart
+  if ! helm upgrade "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set testTag="$__image_tag_suffix" > /dev/null 2>&1; then
+    echo "Failed to upgrade helm chart '$HELM_LOCAL_CHART_NAME' to test image."
+    TEST_PASS=1
+  fi
+}
+
+wait_for_controllers() {
+  if ! should_execute wait_for_controllers; then
+     return 1
+  fi
+  echo "Sleeping 10 seconds for controller pods to come in Running state"
+  sleep 10
+}
+
+ensure_controller_pods() {
+  if ! should_execute ensure_controller_pods; then
+     return 1
+  fi
+
+  echo "Checking status of controller pods"
+  #TODO: make this function more fault tolerant with additional wait time of status is not Running.
+  service_controller_output_lines=$($KUBECTL_PATH get pods | grep "bookstore" | grep "Running" | wc -l)
+  if [[ "$service_controller_output_lines" -gt 0 ]]; then
+    echo "Controller pods have successfully started."
+  else
+    echo "Failed to start controller pods. Exiting... "
+    return 1
+  fi
+}

--- a/scripts/lib/helm.sh
+++ b/scripts/lib/helm.sh
@@ -47,7 +47,8 @@ install_helm_chart() {
   local __image_tag_suffix="$1"
 
   #install the helm chart
-   if ! helm install "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set testTag="$__image_tag_suffix" > /dev/null 2>&1; then
+  #The image name used will be "$AWS_ECR_REGISTRY"/"$AWS_ECR_REPO_NAME":<awsServiceName>-"$__image_tag_suffix"
+   if ! helm install "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set registry="$AWS_ECR_REGISTRY",repo="$AWS_ECR_REPO_NAME",tagSuffix="$__image_tag_suffix" > /dev/null 2>&1; then
      echo "Failed to install helm chart '$HELM_LOCAL_CHART_NAME'."
      TEST_PASS=1
   fi
@@ -70,8 +71,9 @@ upgrade_helm_chart() {
   echo "Upgrading helm chart '$HELM_LOCAL_CHART_NAME' with image tag suffix:test"
   local __image_tag_suffix="$1"
 
-  #install the helm chart
-  if ! helm upgrade "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set testTag="$__image_tag_suffix" > /dev/null 2>&1; then
+  #upgrade the helm chart
+  #The image name used will be "$AWS_ECR_REGISTRY"/"$AWS_ECR_REPO_NAME":<awsServiceName>-"$__image_tag_suffix"
+  if ! helm upgrade "$HELM_LOCAL_CHART_NAME" "$HELM_LOCAL_REPO_NAME"/"$HELM_REPO_CHART_NAME" --set registry="$AWS_ECR_REGISTRY",repo="$AWS_ECR_REPO_NAME",tagSuffix="$__image_tag_suffix" > /dev/null 2>&1; then
     echo "Failed to upgrade helm chart '$HELM_LOCAL_CHART_NAME' to test image."
     TEST_PASS=1
   fi

--- a/services/petstore/Dockerfile
+++ b/services/petstore/Dockerfile
@@ -1,0 +1,29 @@
+# Build the manager binary
+FROM golang:1.14.1 as builder
+
+ARG work_dir=/github.com/aws/aws-service-operator-k8s
+WORKDIR $work_dir
+# For building Go Module required
+ENV GOPROXY=direct
+ENV GO111MODULE=on
+ENV GOARCH=amd64
+ENV GOOS=linux
+ENV CGO_ENABLED=0
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN  go mod download
+# Copy the go source
+# TODO: for now copy whole repository. Later once autogeneration is ready, need to determine which dependencies to take in
+COPY . $work_dir/
+# Build
+RUN  go build -a -o $work_dir/bin/controller $work_dir/services/petstore/cmd/controller/main.go
+
+
+FROM amazonlinux:2
+ARG work_dir=/github.com/aws/aws-service-operator-k8s
+WORKDIR /
+COPY --from=builder $work_dir/bin/controller /bin/.
+ENTRYPOINT ["/bin/controller"]


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Using the temporary docker hub images and helm charts to start service controllers inside the EKS cluster as proof of concept.
* Using this temp repo (https://hub.docker.com/repository/docker/errorbyte/ack) to build helm charts ( https://vijtrip2.github.io/aws-service-operator-k8s/helm/charts/ ) 
--------------
#### Not covered in this PR
* I will update the helm chart to use ECR repository from integration test
* @varun1524 will add the logic of building images for the latest commit and uploading to above mentioned ECR repository

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
