### PR TITLE
correct lookup of referred-to object schemas

### DIFF
--- a/pkg/schema/crd.go
+++ b/pkg/schema/crd.go
@@ -71,7 +71,10 @@ func (h *Helper) GetCRDs() ([]*model.CRD, error) {
 		names := names.New(singularName)
 		sdkObjType := h.sdkObjectTypeFromOp(createOp)
 		crd := model.NewCRD(names, createOp, sdkObjType)
-		inAttrs, outAttrs := h.getAttrsFromOp(createOp, crdName)
+		inAttrs, outAttrs, err := h.getAttrsFromOp(createOp, crdName)
+		if err != nil {
+			return nil, err
+		}
 		inAttrMap := make(map[string]*model.Attr, len(inAttrs))
 		for _, inAttr := range inAttrs {
 			inAttrMap[inAttr.Names.Original] = inAttr

--- a/pkg/schema/helper.go
+++ b/pkg/schema/helper.go
@@ -51,6 +51,17 @@ func (h *Helper) GetAPIGroup() string {
 	return fmt.Sprintf("%s.services.k8s.aws", serviceAlias)
 }
 
+func (h *Helper) GetSchema(schemaName string) *openapi3.Schema {
+	if h.api == nil {
+		return nil
+	}
+	schemaRef := h.api.Components.Schemas[schemaName]
+	if schemaRef == nil {
+		return nil
+	}
+	return schemaRef.Value
+}
+
 func NewHelper(api *openapi3.Swagger) *Helper {
 	return &Helper{api, "", nil}
 }

--- a/pkg/schema/testdata/complex-types.yaml
+++ b/pkg/schema/testdata/complex-types.yaml
@@ -1,0 +1,428 @@
+components:
+  schemas:
+    AnyTag:
+      type: object
+      properties:
+        tags:
+          type: object
+          additionalProperties: true
+    Arn:
+      type: string
+    Attribute:
+      properties:
+        key:
+          $ref: '#/components/schemas/AttributeKey'
+        value:
+          $ref: '#/components/schemas/AttributeValue'
+      required:
+      - key
+      type: object
+    AttributeKey:
+      maxLength: 128
+      minLength: 1
+      type: string
+    AttributeList:
+      items:
+        properties:
+          key:
+            $ref: '#/components/schemas/AttributeKey'
+          value:
+            $ref: '#/components/schemas/AttributeValue'
+        required:
+        - key
+        type: object
+      maxItems: 50
+      type: array
+    AttributeValue:
+      maxLength: 256
+      minLength: 1
+      type: string
+    AuthorizationData:
+      properties:
+        authorizationToken:
+          $ref: '#/components/schemas/Base64'
+        expiresAt:
+          $ref: '#/components/schemas/ExpirationTimestamp'
+        proxyEndpoint:
+          $ref: '#/components/schemas/ProxyEndpoint'
+      type: object
+    AuthorizationDataList:
+      items:
+        properties:
+          authorizationToken:
+            $ref: '#/components/schemas/Base64'
+          expiresAt:
+            $ref: '#/components/schemas/ExpirationTimestamp'
+          proxyEndpoint:
+            $ref: '#/components/schemas/ProxyEndpoint'
+        type: object
+      type: array
+    Base64:
+      pattern: ^\S+$
+      type: string
+    CreationTimestamp:
+      format: date-time
+      type: string
+    DescribeImagesFilter:
+      properties:
+        tagStatus:
+          $ref: '#/components/schemas/TagStatus'
+      type: object
+    EvaluationTimestamp:
+      format: date-time
+      type: string
+    ExceptionMessage:
+      type: string
+    ExpirationTimestamp:
+      format: date-time
+      type: string
+    FindingDescription:
+      type: string
+    FindingName:
+      type: string
+    FindingSeverity:
+      enum:
+      - INFORMATIONAL
+      - LOW
+      - MEDIUM
+      - HIGH
+      - CRITICAL
+      - UNDEFINED
+      type: string
+    FindingSeverityCounts:
+      additionalProperties: true
+      type: object
+    ForceFlag:
+      type: boolean
+    Image:
+      properties:
+        imageId:
+          $ref: '#/components/schemas/ImageIdentifier'
+        imageManifest:
+          $ref: '#/components/schemas/ImageManifest'
+        registryId:
+          $ref: '#/components/schemas/RegistryId'
+        repositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+      type: object
+    ImageActionType:
+      enum:
+      - EXPIRE
+      type: string
+    ImageDetail:
+      properties:
+        imageDigest:
+          $ref: '#/components/schemas/ImageDigest'
+        imagePushedAt:
+          $ref: '#/components/schemas/PushTimestamp'
+        imageScanStatus:
+          $ref: '#/components/schemas/ImageScanStatus'
+        imageSizeInBytes:
+          $ref: '#/components/schemas/ImageSizeInBytes'
+        imageTags:
+          $ref: '#/components/schemas/ImageTagList'
+        registryId:
+          $ref: '#/components/schemas/RegistryId'
+        repositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+      type: object
+    ImageDetailList:
+      items:
+        properties:
+          imageDigest:
+            $ref: '#/components/schemas/ImageDigest'
+          imagePushedAt:
+            $ref: '#/components/schemas/PushTimestamp'
+          imageScanStatus:
+            $ref: '#/components/schemas/ImageScanStatus'
+          imageSizeInBytes:
+            $ref: '#/components/schemas/ImageSizeInBytes'
+          imageTags:
+            $ref: '#/components/schemas/ImageTagList'
+          registryId:
+            $ref: '#/components/schemas/RegistryId'
+          repositoryName:
+            $ref: '#/components/schemas/RepositoryName'
+        type: object
+      type: array
+    ImageDigest:
+      type: string
+    ImageFailure:
+      properties:
+        failureCode:
+          $ref: '#/components/schemas/ImageFailureCode'
+        failureReason:
+          $ref: '#/components/schemas/ImageFailureReason'
+        imageId:
+          $ref: '#/components/schemas/ImageIdentifier'
+      type: object
+    ImageFailureCode:
+      enum:
+      - InvalidImageDigest
+      - InvalidImageTag
+      - ImageTagDoesNotMatchDigest
+      - ImageNotFound
+      - MissingDigestAndTag
+      type: string
+    ImageFailureList:
+      items:
+        properties:
+          failureCode:
+            $ref: '#/components/schemas/ImageFailureCode'
+          failureReason:
+            $ref: '#/components/schemas/ImageFailureReason'
+          imageId:
+            $ref: '#/components/schemas/ImageIdentifier'
+        type: object
+      type: array
+    ImageFailureReason:
+      type: string
+    ImageIdentifier:
+      properties:
+        imageDigest:
+          $ref: '#/components/schemas/ImageDigest'
+        imageTag:
+          $ref: '#/components/schemas/ImageTag'
+      type: object
+    ImageIdentifierList:
+      items:
+        properties:
+          imageDigest:
+            $ref: '#/components/schemas/ImageDigest'
+          imageTag:
+            $ref: '#/components/schemas/ImageTag'
+        type: object
+      maxItems: 100
+      type: array
+    ImageList:
+      items:
+        properties:
+          imageId:
+            $ref: '#/components/schemas/ImageIdentifier'
+          imageManifest:
+            $ref: '#/components/schemas/ImageManifest'
+          registryId:
+            $ref: '#/components/schemas/RegistryId'
+          repositoryName:
+            $ref: '#/components/schemas/RepositoryName'
+        type: object
+      type: array
+    ImageManifest:
+      maxLength: 4194304
+      minLength: 1
+      type: string
+    ImageScanFinding:
+      properties:
+        attributes:
+          $ref: '#/components/schemas/AttributeList'
+        description:
+          $ref: '#/components/schemas/FindingDescription'
+        name:
+          $ref: '#/components/schemas/FindingName'
+        severity:
+          $ref: '#/components/schemas/FindingSeverity'
+        uri:
+          $ref: '#/components/schemas/Url'
+      type: object
+    ImageScanFindingList:
+      items:
+        properties:
+          attributes:
+            $ref: '#/components/schemas/AttributeList'
+          description:
+            $ref: '#/components/schemas/FindingDescription'
+          name:
+            $ref: '#/components/schemas/FindingName'
+          severity:
+            $ref: '#/components/schemas/FindingSeverity'
+          uri:
+            $ref: '#/components/schemas/Url'
+        type: object
+      type: array
+    ImageScanFindings:
+      properties:
+        findingSeverityCounts:
+          $ref: '#/components/schemas/FindingSeverityCounts'
+        findings:
+          $ref: '#/components/schemas/ImageScanFindingList'
+        imageScanCompletedAt:
+          $ref: '#/components/schemas/ScanTimestamp'
+        vulnerabilitySourceUpdatedAt:
+          $ref: '#/components/schemas/VulnerabilitySourceUpdateTimestamp'
+      type: object
+    ImageScanStatus:
+      properties:
+        description:
+          $ref: '#/components/schemas/ScanStatusDescription'
+        status:
+          $ref: '#/components/schemas/ScanStatus'
+      type: object
+    ImageScanningConfiguration:
+      properties:
+        scanOnPush:
+          $ref: '#/components/schemas/ScanOnPushFlag'
+      type: object
+    ImageSizeInBytes:
+      format: int64
+      type: integer
+    ImageTag:
+      maxLength: 300
+      minLength: 1
+      type: string
+    ImageTagAlreadyExistsException:
+      properties:
+        message:
+          $ref: '#/components/schemas/ExceptionMessage'
+      type: object
+      x-aws-api-exception: true
+    ImageTagList:
+      items:
+        maxLength: 300
+        minLength: 1
+        type: string
+      type: array
+    ImageTagMutability:
+      enum:
+      - MUTABLE
+      - IMMUTABLE
+      type: string
+    MediaType:
+      type: string
+    NextToken:
+      type: string
+    PartSize:
+      format: int64
+      minimum: 0
+      type: integer
+    ProxyEndpoint:
+      type: string
+    PushTimestamp:
+      format: date-time
+      type: string
+    RegistryId:
+      pattern: '[0-9]{12}'
+      type: string
+    Repository:
+      properties:
+        createdAt:
+          $ref: '#/components/schemas/CreationTimestamp'
+        imageScanningConfiguration:
+          $ref: '#/components/schemas/ImageScanningConfiguration'
+        imageTagMutability:
+          $ref: '#/components/schemas/ImageTagMutability'
+        registryId:
+          $ref: '#/components/schemas/RegistryId'
+        repositoryArn:
+          $ref: '#/components/schemas/Arn'
+        repositoryName:
+          $ref: '#/components/schemas/RepositoryName'
+        repositoryUri:
+          $ref: '#/components/schemas/Url'
+      type: object
+    RepositoryList:
+      items:
+        properties:
+          createdAt:
+            $ref: '#/components/schemas/CreationTimestamp'
+          imageScanningConfiguration:
+            $ref: '#/components/schemas/ImageScanningConfiguration'
+          imageTagMutability:
+            $ref: '#/components/schemas/ImageTagMutability'
+          registryId:
+            $ref: '#/components/schemas/RegistryId'
+          repositoryArn:
+            $ref: '#/components/schemas/Arn'
+          repositoryName:
+            $ref: '#/components/schemas/RepositoryName'
+          repositoryUri:
+            $ref: '#/components/schemas/Url'
+        type: object
+      type: array
+    RepositoryName:
+      maxLength: 256
+      minLength: 2
+      pattern: (?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*
+      type: string
+    RepositoryNameList:
+      items:
+        maxLength: 256
+        minLength: 2
+        pattern: (?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*
+        type: string
+      maxItems: 100
+      type: array
+    RepositoryPolicyText:
+      maxLength: 10240
+      type: string
+    ScanOnPushFlag:
+      type: boolean
+    ScanStatus:
+      enum:
+      - IN_PROGRESS
+      - COMPLETE
+      - FAILED
+      type: string
+    ScanStatusDescription:
+      type: string
+    ScanTimestamp:
+      format: date-time
+      type: string
+    SeverityCount:
+      format: int64
+      minimum: 0
+      type: integer
+    Tag:
+      properties:
+        Key:
+          $ref: '#/components/schemas/TagKey'
+        Value:
+          $ref: '#/components/schemas/TagValue'
+      type: object
+    TagKey:
+      type: string
+    TagKeyList:
+      items:
+        type: string
+      type: array
+    TagList:
+      items:
+        properties:
+          Key:
+            $ref: '#/components/schemas/TagKey'
+          Value:
+            $ref: '#/components/schemas/TagValue'
+        type: object
+      type: array
+    TagStatus:
+      enum:
+      - TAGGED
+      - UNTAGGED
+      - ANY
+      type: string
+    TagValue:
+      type: string
+    UnknownType:
+      properties:
+        field:
+          type: unknown
+      type: object
+    UnknownImageScanFindingList:
+      type: array
+      items:
+        type: object
+        properties:
+          field:
+            type: string
+    UnknownImageScanFindings:
+      properties:
+        findings:
+          $ref: '#/components/schemas/UnknownImageScanFindingList'
+      type: object
+    UploadId:
+      pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+      type: string
+    Url:
+      type: string
+    VulnerabilitySourceUpdateTimestamp:
+      format: date-time
+      type: string

--- a/pkg/schema/type_def.go
+++ b/pkg/schema/type_def.go
@@ -56,7 +56,10 @@ func (h *Helper) GetTypeDefs() ([]*model.TypeDef, error) {
 		for propName, propSchemaRef := range schema.Properties {
 			propSchema := h.getSchemaFromSchemaRef(propSchemaRef)
 			propNames := names.New(propName)
-			goType := h.getGoTypeFromSchema(propNames.Camel, propSchema)
+			goType, err := h.GetGoTypeFromSchemaRef(propNames, propSchemaRef)
+			if err != nil {
+				return nil, err
+			}
 			attrs[propName] = model.NewAttr(propNames, goType, propSchema)
 		}
 		if len(attrs) == 0 {

--- a/pkg/schema/util_test.go
+++ b/pkg/schema/util_test.go
@@ -1,0 +1,120 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package schema_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/aws-service-operator-k8s/pkg/names"
+	"github.com/aws/aws-service-operator-k8s/pkg/testutil"
+)
+
+func TestGoTypeFromSchemaRef(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	tests := []struct {
+		name       string
+		schemaName string
+		propNames  names.Names
+		expGoType  string
+		expErr     error
+	}{
+		{
+			"string type",
+			"Attribute",
+			names.New("value"),
+			"string",
+			nil,
+		},
+		{
+			"boolean type",
+			"ImageScanningConfiguration",
+			names.New("scanOnPush"),
+			"bool",
+			nil,
+		},
+		{
+			"int64 type",
+			"ImageDetail",
+			names.New("imageSizeInBytes"),
+			"int64",
+			nil,
+		},
+		{
+			"object type",
+			"ImageDetail",
+			names.New("imageScanStatus"),
+			"*ImageScanStatus",
+			nil,
+		},
+		{
+			"simple array type",
+			"ImageDetail",
+			names.New("imageTags"),
+			"[]string",
+			nil,
+		},
+		{
+			"object array type",
+			"ImageScanFindings",
+			names.New("findings"),
+			"[]*ImageScanFinding",
+			nil,
+		},
+		{
+			"map[string]string type",
+			"AnyTag",
+			names.New("tags"),
+			"map[string]string",
+			nil,
+		},
+		{
+			"unknown type",
+			"UnknownType",
+			names.New("field"),
+			"",
+			fmt.Errorf("failed to determine Go type. schema.Type was %s", "unknown"),
+		},
+		{
+			"unknown array items referred-to type",
+			"UnknownImageScanFindings",
+			names.New("findings"),
+			"",
+			fmt.Errorf("failed to find %s when looking up arrayTypeName %s", "UnknownImageScanFinding", "UnknownImageScanFindingList"),
+		},
+	}
+	for _, test := range tests {
+		sh := testutil.NewSchemaHelperFromFile(t, "complex-types.yaml")
+
+		schema := sh.GetSchema(test.schemaName)
+		require.NotNil(schema)
+
+		propSchemaRef := schema.Properties[test.propNames.Original]
+		require.NotNil(propSchemaRef, test.name)
+
+		gt, err := sh.GetGoTypeFromSchemaRef(test.propNames, propSchemaRef)
+		if test.expErr != nil {
+			assert.Error(err)
+			assert.Equal(test.expErr, err)
+		} else {
+			assert.Nil(err, "expected err to be nil but got %s", err)
+		}
+		assert.Equal(test.expGoType, gt)
+	}
+}


### PR DESCRIPTION
When determining the Go type for schemas of type "object" or "array of
object", we were searching for the referred-to schema using the wrong
name. For the case of schemas with a type of "object", we were passing
the name of the property, camel-cased. In the case of the "array of
object" type schemas, we were using the name of the property instead of
the name of the schema being referred to.

What this meant was that, for example, the ECR API's ImageScanFindings
object's "findings" property, which looks like this:

```yaml
    ImageScanFindings:
      properties:
        findingSeverityCounts:
          $ref: '#/components/schemas/FindingSeverityCounts'
        findings:
          $ref: '#/components/schemas/ImageScanFindingList'
        imageScanCompletedAt:
          $ref: '#/components/schemas/ScanTimestamp'
        vulnerabilitySourceUpdatedAt:
          $ref: '#/components/schemas/VulnerabilitySourceUpdateTimestamp'
      type: object
    ImageScanFindingList:
      items:
        properties:
          attributes:
            $ref: '#/components/schemas/AttributeList'
          description:
            $ref: '#/components/schemas/FindingDescription'
          name:
            $ref: '#/components/schemas/FindingName'
          severity:
            $ref: '#/components/schemas/FindingSeverity'
          uri:
            $ref: '#/components/schemas/Url'
        type: object
      type: array
    ImageScanFinding:
      properties:
        attributes:
          $ref: '#/components/schemas/AttributeList'
        description:
          $ref: '#/components/schemas/FindingDescription'
        name:
          $ref: '#/components/schemas/FindingName'
        severity:
          $ref: '#/components/schemas/FindingSeverity'
        uri:
          $ref: '#/components/schemas/Url'
      type: object
```

we were looking for a schema named "Findings" instead of
"ImageScanFindings".

Fixes Issue #64

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
