### PR TITLE
remove CRD name prefix in resource pkg objects

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -51,20 +51,6 @@ func (_m *AWSResourceManager) Delete(_a0 context.Context, _a1 types.AWSResource)
 	return r0
 }
 
-// Exists provides a mock function with given fields: _a0, _a1
-func (_m *AWSResourceManager) Exists(_a0 context.Context, _a1 types.AWSResource) bool {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource) bool); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 // ReadOne provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) ReadOne(_a0 context.Context, _a1 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1)

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -26,9 +26,6 @@ import (
 // Use an AWSResourceManagerFactory to create an AWSResourceManager for a
 // particular APIResource and AWS account.
 type AWSResourceManager interface {
-	// Exists returns true if the supplied resource exists in the backend AWS
-	// service API.
-	Exists(context.Context, AWSResource) bool
 	// ReadOne returns the currently-observed state of the supplied AWSResource
 	// in the backend AWS service API.
 	//

--- a/services/bookstore/pkg/resource/book/descriptor.go
+++ b/services/bookstore/pkg/resource/book/descriptor.go
@@ -29,35 +29,35 @@ const (
 )
 
 var (
-	bookResourceGK = metav1.GroupKind{
+	resourceGK = metav1.GroupKind{
 		Group: "bookstore.services.k8s.aws",
 		Kind:  "Book",
 	}
 )
 
-// bookResourceDescriptor implements the
+// resourceDescriptor implements the
 // `aws-service-operator-k8s/pkg/types.AWSResourceDescriptor` interface
-type bookResourceDescriptor struct {
+type resourceDescriptor struct {
 }
 
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
-func (d *bookResourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &bookResourceGK
+func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
+	return &resourceGK
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in
 // apimachinery and k8s client operations
-func (d *bookResourceDescriptor) EmptyRuntimeObject() k8sapirt.Object {
+func (d *resourceDescriptor) EmptyRuntimeObject() k8sapirt.Object {
 	return &svcapitypes.Book{}
 }
 
 // ResourceFromRuntimeObject returns an AWSResource that has been initialized
 // with the supplied runtime.Object
-func (d *bookResourceDescriptor) ResourceFromRuntimeObject(
+func (d *resourceDescriptor) ResourceFromRuntimeObject(
 	obj k8sapirt.Object,
 ) acktypes.AWSResource {
-	return &bookResource{
+	return &resource{
 		ko: obj.(*svcapitypes.Book),
 	}
 }
@@ -66,12 +66,12 @@ func (d *bookResourceDescriptor) ResourceFromRuntimeObject(
 // The underlying types of the two supplied AWSResources should be the same. In
 // other words, the Equal() method should be called with the same concrete
 // implementing AWSResource type
-func (d *bookResourceDescriptor) Equal(
+func (d *resourceDescriptor) Equal(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
 ) bool {
-	ac := a.(*bookResource)
-	bc := b.(*bookResource)
+	ac := a.(*resource)
+	bc := b.(*resource)
 	opts := cmpopts.EquateEmpty()
 	return cmp.Equal(ac.sdko, bc.sdko, opts)
 }
@@ -80,12 +80,12 @@ func (d *bookResourceDescriptor) Equal(
 // AWSResources/ The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
-func (d *bookResourceDescriptor) Diff(
+func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
 ) string {
-	ac := a.(*bookResource)
-	bc := b.(*bookResource)
+	ac := a.(*resource)
+	bc := b.(*resource)
 	opts := cmpopts.EquateEmpty()
 	return cmp.Diff(ac.sdko, bc.sdko, opts)
 }
@@ -93,7 +93,7 @@ func (d *bookResourceDescriptor) Diff(
 // UpdateCRStatus accepts an AWSResource object and changes the Status
 // sub-object of the AWSResource's Kubernetes custom resource (CR) and
 // returns whether any changes were made
-func (d *bookResourceDescriptor) UpdateCRStatus(
+func (d *resourceDescriptor) UpdateCRStatus(
 	res acktypes.AWSResource,
 ) (bool, error) {
 	updated := false
@@ -104,7 +104,7 @@ func (d *bookResourceDescriptor) UpdateCRStatus(
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a
 // resource-specific finalizer associated with it.
-func (d *bookResourceDescriptor) IsManaged(
+func (d *resourceDescriptor) IsManaged(
 	res acktypes.AWSResource,
 ) bool {
 	obj := res.RuntimeMetaObject()
@@ -138,7 +138,7 @@ func containsFinalizer(obj acktypes.RuntimeMetaObject, finalizer string) bool {
 // managing the resource and the underlying CR may not be deleted until ACK is
 // finished cleaning up any backend AWS service resources associated with the
 // CR.
-func (d *bookResourceDescriptor) MarkManaged(
+func (d *resourceDescriptor) MarkManaged(
 	res acktypes.AWSResource,
 ) {
 	obj := res.RuntimeMetaObject()
@@ -153,7 +153,7 @@ func (d *bookResourceDescriptor) MarkManaged(
 // this typically means is that the resource manager will remove a finalizer
 // underlying custom resource (CR) that indicates ACK is managing the resource.
 // This will allow the Kubernetes API server to delete the underlying CR.
-func (d *bookResourceDescriptor) MarkUnmanaged(
+func (d *resourceDescriptor) MarkUnmanaged(
 	res acktypes.AWSResource,
 ) {
 	obj := res.RuntimeMetaObject()

--- a/services/bookstore/pkg/resource/book/identifiers.go
+++ b/services/bookstore/pkg/resource/book/identifiers.go
@@ -18,16 +18,16 @@ import (
 	// svcapitypes "github.com/aws/aws-sdk-go/service/apis/{{ .AWSServiceVersion}}
 )
 
-// bookResourceIdentifiers implements the
+// resourceIdentifiers implements the
 // `aws-service-operator-k8s/pkg/types.AWSResourceIdentifiers` interface
-type bookResourceIdentifiers struct {
+type resourceIdentifiers struct {
 	meta *ackv1alpha1.ResourceMetadata
 }
 
 // ARN returns the AWS Resource Name for the backend AWS resource. If nil,
 // this means the resource has not yet been created in the backend AWS
 // service.
-func (ri *bookResourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
+func (ri *resourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
 	if ri.meta != nil {
 		return ri.meta.ARN
 	}
@@ -37,7 +37,7 @@ func (ri *bookResourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
 // OwnerAccountID returns the AWS account identifier in which the
 // backend AWS resource resides, or nil if this information is not known
 // for the resource
-func (ri *bookResourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
+func (ri *resourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	if ri.meta != nil {
 		return ri.meta.OwnerAccountID
 	}

--- a/services/bookstore/pkg/resource/book/manager.go
+++ b/services/bookstore/pkg/resource/book/manager.go
@@ -32,9 +32,9 @@ import (
 	svcsdk "github.com/aws/aws-service-operator-k8s/services/bookstore/sdk/service/bookstore"
 )
 
-// bookResourceManager is responsible for providing a consistent way to perform
+// resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
-type bookResourceManager struct {
+type resourceManager struct {
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -46,19 +46,19 @@ type bookResourceManager struct {
 	sdkapi svcsdkapi.BookstoreAPI
 }
 
-// concreteResource returns a pointer to a bookResource from the supplied
+// concreteResource returns a pointer to a resource from the supplied
 // generic AWSResource interface
-func (rm *bookResourceManager) concreteResource(
+func (rm *resourceManager) concreteResource(
 	res acktypes.AWSResource,
-) *bookResource {
+) *resource {
 	// cast the generic interface into a pointer type specific to the concrete
 	// implementing resource type managed by this resource manager
-	return res.(*bookResource)
+	return res.(*resource)
 }
 
 // ReadOne returns the currently-observed state of the supplied AWSResource in
 // the backend AWS service API.
-func (rm *bookResourceManager) ReadOne(
+func (rm *resourceManager) ReadOne(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -67,16 +67,16 @@ func (rm *bookResourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return &bookResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: sdko,
 	}, nil
 }
 
-// findSDKBook returns SDK-specific information about a supplied bookResource
-func (rm *bookResourceManager) findSDKBook(
+// findSDKBook returns SDK-specific information about a supplied resource
+func (rm *resourceManager) findSDKBook(
 	ctx context.Context,
-	r *bookResource,
+	r *resource,
 ) (*svcsdk.BookData, error) {
 	input := svcsdk.DescribeBookInput{
 		BookName:  r.ko.Spec.Name,
@@ -95,7 +95,7 @@ func (rm *bookResourceManager) findSDKBook(
 // Create attempts to create the supplied AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-created
 // resource
-func (rm *bookResourceManager) Create(
+func (rm *resourceManager) Create(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -107,7 +107,7 @@ func (rm *bookResourceManager) Create(
 	if err != nil {
 		return nil, err
 	}
-	return &bookResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: resp.Book,
 	}, nil
@@ -119,7 +119,7 @@ func (rm *bookResourceManager) Create(
 // observed resource differs from the supplied desired state. The higher-level
 // reonciler determines whether or not the desired differs from the latest
 // observed and decides whether to call the resource manager's Update method
-func (rm *bookResourceManager) Update(
+func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -139,14 +139,14 @@ func (rm *bookResourceManager) Update(
 	if err != nil {
 		return nil, err
 	}
-	return &bookResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: resp.Book,
 	}, nil
 }
 
 // sdkoFromKO constructs a BookData object from a Book CR
-func (rm *bookResourceManager) sdkoFromKO(
+func (rm *resourceManager) sdkoFromKO(
 	ko *svcapitypes.Book,
 ) (*svcsdk.BookData, error) {
 	// TODO(jaypipes): isolate conversion/translation logic here. I'm not a
@@ -163,7 +163,7 @@ func (rm *bookResourceManager) sdkoFromKO(
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
 // service API.
-func (rm *bookResourceManager) Delete(
+func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) error {
@@ -179,14 +179,14 @@ func (rm *bookResourceManager) Delete(
 	return err
 }
 
-func newBookResourceManager(
+func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
-) (*bookResourceManager, error) {
+) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
 	if err != nil {
 		return nil, err
 	}
-	return &bookResourceManager{
+	return &resourceManager{
 		awsAccountID: id,
 		sess:         sess,
 	}, nil

--- a/services/bookstore/pkg/resource/book/manager.go
+++ b/services/bookstore/pkg/resource/book/manager.go
@@ -56,15 +56,6 @@ func (rm *bookResourceManager) concreteResource(
 	return res.(*bookResource)
 }
 
-// Exists returns true if the supplied AWSResource exists in the backend AWS
-// service API.
-func (rm *bookResourceManager) Exists(
-	ctx context.Context,
-	res acktypes.AWSResource,
-) bool {
-	return false
-}
-
 // ReadOne returns the currently-observed state of the supplied AWSResource in
 // the backend AWS service API.
 func (rm *bookResourceManager) ReadOne(

--- a/services/bookstore/pkg/resource/book/manager_factory.go
+++ b/services/bookstore/pkg/resource/book/manager_factory.go
@@ -22,23 +22,23 @@ import (
 	svcresource "github.com/aws/aws-service-operator-k8s/services/bookstore/pkg/resource"
 )
 
-// bookResourceManagerFactory produces bookResourceManager objects. It
+// resourceManagerFactory produces resourceManager objects. It
 // implements the `types.AWSResourceManagerFactory` interface.
-type bookResourceManagerFactory struct {
+type resourceManagerFactory struct {
 	sync.RWMutex
 	// rmCache contains resource managers for a particular AWS account ID
-	rmCache map[ackv1alpha1.AWSAccountID]*bookResourceManager
+	rmCache map[ackv1alpha1.AWSAccountID]*resourceManager
 }
 
 // ResourcePrototype returns an AWSResource that resource managers produced by
 // this factory will handle
-func (f *bookResourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
-	return &bookResourceDescriptor{}
+func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
+	return &resourceDescriptor{}
 }
 
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
-func (f *bookResourceManagerFactory) ManagerFor(
+func (f *resourceManagerFactory) ManagerFor(
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -52,7 +52,7 @@ func (f *bookResourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newBookResourceManager(id)
+	rm, err := newResourceManager(id)
 	if err != nil {
 		return nil, err
 	}
@@ -60,12 +60,12 @@ func (f *bookResourceManagerFactory) ManagerFor(
 	return rm, nil
 }
 
-func newBookResourceManagerFactory() *bookResourceManagerFactory {
-	return &bookResourceManagerFactory{
-		rmCache: map[ackv1alpha1.AWSAccountID]*bookResourceManager{},
+func newResourceManagerFactory() *resourceManagerFactory {
+	return &resourceManagerFactory{
+		rmCache: map[ackv1alpha1.AWSAccountID]*resourceManager{},
 	}
 }
 
 func init() {
-	svcresource.RegisterManagerFactory(newBookResourceManagerFactory())
+	svcresource.RegisterManagerFactory(newResourceManagerFactory())
 }

--- a/services/bookstore/pkg/resource/book/resource.go
+++ b/services/bookstore/pkg/resource/book/resource.go
@@ -25,9 +25,9 @@ import (
 	svcsdk "github.com/aws/aws-service-operator-k8s/services/bookstore/sdk/service/bookstore"
 )
 
-// bookResource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
+// resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
 // interface
-type bookResource struct {
+type resource struct {
 	// The Kubernetes-native CR representing the resource
 	ko *svcapitypes.Book
 	// The aws-sdk-go-native representation of the resource
@@ -37,36 +37,36 @@ type bookResource struct {
 // Identifiers returns an AWSResourceIdentifiers object containing various
 // identifying information, including the AWS account ID that owns the
 // resource, the resource's AWS Resource Name (ARN)
-func (r *bookResource) Identifiers() acktypes.AWSResourceIdentifiers {
-	return &bookResourceIdentifiers{r.ko.Status.ACKResourceMetadata}
+func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
+	return &resourceIdentifiers{r.ko.Status.ACKResourceMetadata}
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
 // deletion timestemp
-func (r *bookResource) IsBeingDeleted() bool {
+func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }
 
 // RuntimeObject returns the Kubernetes apimachinery/runtime representation of
 // the AWSResource
-func (r *bookResource) RuntimeObject() k8srt.Object {
+func (r *resource) RuntimeObject() k8srt.Object {
 	return r.ko
 }
 
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
-func (r *bookResource) MetaObject() metav1.Object {
+func (r *resource) MetaObject() metav1.Object {
 	return r.ko
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes
 // apimachinery/runtime.Object and the Kubernetes
 // apimachinery/apis/meta/v1.Object interfaces
-func (r *bookResource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
+func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 	return r.ko
 }
 
 // Conditions returns the ACK Conditions collection for the AWSResource
-func (r *bookResource) Conditions() []*ackv1alpha1.Condition {
+func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }

--- a/services/petstore/pkg/resource/pet/descriptor.go
+++ b/services/petstore/pkg/resource/pet/descriptor.go
@@ -29,35 +29,35 @@ const (
 )
 
 var (
-	petResourceGK = metav1.GroupKind{
+	resourceGK = metav1.GroupKind{
 		Group: "petstore.services.k8s.aws",
 		Kind:  "Pet",
 	}
 )
 
-// petResourceDescriptor implements the
+// resourceDescriptor implements the
 // `aws-service-operator-k8s/pkg/types.AWSResourceDescriptor` interface
-type petResourceDescriptor struct {
+type resourceDescriptor struct {
 }
 
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
-func (d *petResourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &petResourceGK
+func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
+	return &resourceGK
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in
 // apimachinery and k8s client operations
-func (d *petResourceDescriptor) EmptyRuntimeObject() k8sapirt.Object {
+func (d *resourceDescriptor) EmptyRuntimeObject() k8sapirt.Object {
 	return &svcapitypes.Pet{}
 }
 
 // ResourceFromRuntimeObject returns an AWSResource that has been initialized
 // with the supplied runtime.Object
-func (d *petResourceDescriptor) ResourceFromRuntimeObject(
+func (d *resourceDescriptor) ResourceFromRuntimeObject(
 	obj k8sapirt.Object,
 ) acktypes.AWSResource {
-	return &petResource{
+	return &resource{
 		ko: obj.(*svcapitypes.Pet),
 	}
 }
@@ -66,12 +66,12 @@ func (d *petResourceDescriptor) ResourceFromRuntimeObject(
 // The underlying types of the two supplied AWSResources should be the same. In
 // other words, the Equal() method should be called with the same concrete
 // implementing AWSResource type
-func (d *petResourceDescriptor) Equal(
+func (d *resourceDescriptor) Equal(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
 ) bool {
-	ac := a.(*petResource)
-	bc := b.(*petResource)
+	ac := a.(*resource)
+	bc := b.(*resource)
 	opts := cmpopts.EquateEmpty()
 	return cmp.Equal(ac.sdko, bc.sdko, opts)
 }
@@ -80,12 +80,12 @@ func (d *petResourceDescriptor) Equal(
 // AWSResources/ The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
-func (d *petResourceDescriptor) Diff(
+func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
 ) string {
-	ac := a.(*petResource)
-	bc := b.(*petResource)
+	ac := a.(*resource)
+	bc := b.(*resource)
 	opts := cmpopts.EquateEmpty()
 	return cmp.Diff(ac.sdko, bc.sdko, opts)
 }
@@ -93,7 +93,7 @@ func (d *petResourceDescriptor) Diff(
 // UpdateCRStatus accepts an AWSResource object and changes the Status
 // sub-object of the AWSResource's Kubernetes custom resource (CR) and
 // returns whether any changes were made
-func (d *petResourceDescriptor) UpdateCRStatus(
+func (d *resourceDescriptor) UpdateCRStatus(
 	res acktypes.AWSResource,
 ) (bool, error) {
 	updated := false
@@ -104,7 +104,7 @@ func (d *petResourceDescriptor) UpdateCRStatus(
 // of an ACK service controller. What this means in practice is that the
 // underlying custom resource (CR) in the AWSResource has had a
 // resource-specific finalizer associated with it.
-func (d *petResourceDescriptor) IsManaged(
+func (d *resourceDescriptor) IsManaged(
 	res acktypes.AWSResource,
 ) bool {
 	obj := res.RuntimeMetaObject()
@@ -138,7 +138,7 @@ func containsFinalizer(obj acktypes.RuntimeMetaObject, finalizer string) bool {
 // managing the resource and the underlying CR may not be deleted until ACK is
 // finished cleaning up any backend AWS service resources associated with the
 // CR.
-func (d *petResourceDescriptor) MarkManaged(
+func (d *resourceDescriptor) MarkManaged(
 	res acktypes.AWSResource,
 ) {
 	obj := res.RuntimeMetaObject()
@@ -153,7 +153,7 @@ func (d *petResourceDescriptor) MarkManaged(
 // this typically means is that the resource manager will remove a finalizer
 // underlying custom resource (CR) that indicates ACK is managing the resource.
 // This will allow the Kubernetes API server to delete the underlying CR.
-func (d *petResourceDescriptor) MarkUnmanaged(
+func (d *resourceDescriptor) MarkUnmanaged(
 	res acktypes.AWSResource,
 ) {
 	obj := res.RuntimeMetaObject()

--- a/services/petstore/pkg/resource/pet/identifiers.go
+++ b/services/petstore/pkg/resource/pet/identifiers.go
@@ -18,16 +18,16 @@ import (
 	// svcapitypes "github.com/aws/aws-sdk-go/service/apis/{{ .AWSServiceVersion}}
 )
 
-// petResourceIdentifiers implements the
+// resourceIdentifiers implements the
 // `aws-service-operator-k8s/pkg/types.AWSResourceIdentifiers` interface
-type petResourceIdentifiers struct {
+type resourceIdentifiers struct {
 	meta *ackv1alpha1.ResourceMetadata
 }
 
 // ARN returns the AWS Resource Name for the backend AWS resource. If nil,
 // this means the resource has not yet been created in the backend AWS
 // service.
-func (ri *petResourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
+func (ri *resourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
 	if ri.meta != nil {
 		return ri.meta.ARN
 	}
@@ -37,7 +37,7 @@ func (ri *petResourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
 // OwnerAccountID returns the AWS account identifier in which the
 // backend AWS resource resides, or nil if this information is not known
 // for the resource
-func (ri *petResourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
+func (ri *resourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	if ri.meta != nil {
 		return ri.meta.OwnerAccountID
 	}

--- a/services/petstore/pkg/resource/pet/manager.go
+++ b/services/petstore/pkg/resource/pet/manager.go
@@ -31,9 +31,9 @@ import (
 	svcsdk "github.com/aws/aws-service-operator-k8s/services/petstore/sdk/service/petstore"
 )
 
-// petResourceManager is responsible for providing a consistent way to perform
+// resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Pet custom resources.
-type petResourceManager struct {
+type resourceManager struct {
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -45,19 +45,19 @@ type petResourceManager struct {
 	sdkapi svcsdkapi.PetstoreAPI
 }
 
-// concreteResource returns a pointer to a petResource from the supplied
+// concreteResource returns a pointer to a resource from the supplied
 // generic AWSResource interface
-func (rm *petResourceManager) concreteResource(
+func (rm *resourceManager) concreteResource(
 	res acktypes.AWSResource,
-) *petResource {
+) *resource {
 	// cast the generic interface into a pointer type specific to the concrete
 	// implementing resource type managed by this resource manager
-	return res.(*petResource)
+	return res.(*resource)
 }
 
 // ReadOne returns the currently-observed state of the supplied AWSResource in
 // the backend AWS service API.
-func (rm *petResourceManager) ReadOne(
+func (rm *resourceManager) ReadOne(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -66,16 +66,16 @@ func (rm *petResourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return &petResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: sdko,
 	}, nil
 }
 
-// findSDKPet returns SDK-specific information about a supplied petResource
-func (rm *petResourceManager) findSDKPet(
+// findSDKPet returns SDK-specific information about a supplied resource
+func (rm *resourceManager) findSDKPet(
 	ctx context.Context,
-	r *petResource,
+	r *resource,
 ) (*svcsdk.PetData, error) {
 	input := svcsdk.DescribePetInput{
 		PetName:  r.ko.Spec.Name,
@@ -94,7 +94,7 @@ func (rm *petResourceManager) findSDKPet(
 // Create attempts to create the supplied AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-created
 // resource
-func (rm *petResourceManager) Create(
+func (rm *resourceManager) Create(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -106,7 +106,7 @@ func (rm *petResourceManager) Create(
 	if err != nil {
 		return nil, err
 	}
-	return &petResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: resp.Pet,
 	}, nil
@@ -118,7 +118,7 @@ func (rm *petResourceManager) Create(
 // observed resource differs from the supplied desired state. The higher-level
 // reonciler determines whether or not the desired differs from the latest
 // observed and decides whether to call the resource manager's Update method
-func (rm *petResourceManager) Update(
+func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
@@ -138,14 +138,14 @@ func (rm *petResourceManager) Update(
 	if err != nil {
 		return nil, err
 	}
-	return &petResource{
+	return &resource{
 		ko:   r.ko,
 		sdko: resp.Pet,
 	}, nil
 }
 
 // sdkoFromKO constructs a PetData object from a Pet CR
-func (rm *petResourceManager) sdkoFromKO(
+func (rm *resourceManager) sdkoFromKO(
 	ko *svcapitypes.Pet,
 ) (*svcsdk.PetData, error) {
 	// TODO(jaypipes): isolate conversion/translation logic here. I'm not a
@@ -162,7 +162,7 @@ func (rm *petResourceManager) sdkoFromKO(
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
 // service API.
-func (rm *petResourceManager) Delete(
+func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
 ) error {
@@ -178,14 +178,14 @@ func (rm *petResourceManager) Delete(
 	return err
 }
 
-func newPetResourceManager(
+func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
-) (*petResourceManager, error) {
+) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
 	if err != nil {
 		return nil, err
 	}
-	return &petResourceManager{
+	return &resourceManager{
 		awsAccountID: id,
 		sess:         sess,
 	}, nil

--- a/services/petstore/pkg/resource/pet/manager.go
+++ b/services/petstore/pkg/resource/pet/manager.go
@@ -55,15 +55,6 @@ func (rm *petResourceManager) concreteResource(
 	return res.(*petResource)
 }
 
-// Exists returns true if the supplied AWSResource exists in the backend AWS
-// service API.
-func (rm *petResourceManager) Exists(
-	ctx context.Context,
-	res acktypes.AWSResource,
-) bool {
-	return false
-}
-
 // ReadOne returns the currently-observed state of the supplied AWSResource in
 // the backend AWS service API.
 func (rm *petResourceManager) ReadOne(

--- a/services/petstore/pkg/resource/pet/manager_factory.go
+++ b/services/petstore/pkg/resource/pet/manager_factory.go
@@ -21,29 +21,29 @@ import (
 	svcresource "github.com/aws/aws-service-operator-k8s/services/petstore/pkg/resource"
 )
 
-// petResourceManagerFactory produces petResourceManager objects. It
+// resourceManagerFactory produces resourceManager objects. It
 // implements the `types.AWSResourceManagerFactory` interface.
-type petResourceManagerFactory struct {
+type resourceManagerFactory struct {
 	sync.RWMutex
 	// rmCache contains resource managers for a particular AWS account ID
-	rmCache map[ackv1alpha1.AWSAccountID]*petResourceManager
+	rmCache map[ackv1alpha1.AWSAccountID]*resourceManager
 }
 
 // ResourcePrototype returns an AWSResource that resource managers produced by
 // this factory will handle
-func (f *petResourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
-	return &petResourceDescriptor{}
+func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
+	return &resourceDescriptor{}
 }
 
 // GroupKind returns a string representation of the CRs handled by this
 // resource manager
-func (f *petResourceManagerFactory) GroupKind() string {
+func (f *resourceManagerFactory) GroupKind() string {
 	return "example.services.k8s.aws:Pet"
 }
 
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
-func (f *petResourceManagerFactory) ManagerFor(
+func (f *resourceManagerFactory) ManagerFor(
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -57,7 +57,7 @@ func (f *petResourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newPetResourceManager(id)
+	rm, err := newResourceManager(id)
 	if err != nil {
 		return nil, err
 	}
@@ -65,12 +65,12 @@ func (f *petResourceManagerFactory) ManagerFor(
 	return rm, nil
 }
 
-func newPetResourceManagerFactory() *petResourceManagerFactory {
-	return &petResourceManagerFactory{
-		rmCache: map[ackv1alpha1.AWSAccountID]*petResourceManager{},
+func newResourceManagerFactory() *resourceManagerFactory {
+	return &resourceManagerFactory{
+		rmCache: map[ackv1alpha1.AWSAccountID]*resourceManager{},
 	}
 }
 
 func init() {
-	svcresource.RegisterManagerFactory(newPetResourceManagerFactory())
+	svcresource.RegisterManagerFactory(newResourceManagerFactory())
 }

--- a/services/petstore/pkg/resource/pet/resource.go
+++ b/services/petstore/pkg/resource/pet/resource.go
@@ -25,9 +25,9 @@ import (
 	svcsdk "github.com/aws/aws-service-operator-k8s/services/petstore/sdk/service/petstore"
 )
 
-// petResource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
+// resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
 // interface
-type petResource struct {
+type resource struct {
 	// The Kubernetes-native CR representing the resource
 	ko *svcapitypes.Pet
 	// The aws-sdk-go-native representation of the resource
@@ -37,36 +37,36 @@ type petResource struct {
 // Identifiers returns an AWSResourceIdentifiers object containing various
 // identifying information, including the AWS account ID that owns the
 // resource, the resource's AWS Resource Name (ARN)
-func (r *petResource) Identifiers() acktypes.AWSResourceIdentifiers {
-	return &petResourceIdentifiers{r.ko.Status.ACKResourceMetadata}
+func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
+	return &resourceIdentifiers{r.ko.Status.ACKResourceMetadata}
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
 // deletion timestemp
-func (r *petResource) IsBeingDeleted() bool {
+func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }
 
 // RuntimeObject returns the Kubernetes apimachinery/runtime representation of
 // the AWSResource
-func (r *petResource) RuntimeObject() k8srt.Object {
+func (r *resource) RuntimeObject() k8srt.Object {
 	return r.ko
 }
 
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
-func (r *petResource) MetaObject() metav1.Object {
+func (r *resource) MetaObject() metav1.Object {
 	return r.ko
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes
 // apimachinery/runtime.Object and the Kubernetes
 // apimachinery/apis/meta/v1.Object interfaces
-func (r *petResource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
+func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 	return r.ko
 }
 
 // Conditions returns the ACK Conditions collection for the AWSResource
-func (r *petResource) Conditions() []*ackv1alpha1.Condition {
+func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }

--- a/templates/pkg/crd_identifiers.go.tpl
+++ b/templates/pkg/crd_identifiers.go.tpl
@@ -6,16 +6,16 @@ import (
 	ackv1alpha1 "github.com/aws/aws-service-operator-k8s/apis/core/v1alpha1"
 )
 
-// {{ .CRD.Names.CamelLower }}ResourceIdentifiers implements the
+// resourceIdentifiers implements the
 // `aws-service-operator-k8s/pkg/types.AWSResourceIdentifiers` interface
-type {{ .CRD.Names.CamelLower }}ResourceIdentifiers struct {
+type resourceIdentifiers struct {
 	meta *ackv1alpha1.ResourceMetadata
 }
 
 // ARN returns the AWS Resource Name for the backend AWS resource. If nil,
 // this means the resource has not yet been created in the backend AWS
 // service.
-func (ri *{{ .CRD.Names.CamelLower }}ResourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
+func (ri *resourceIdentifiers) ARN() *ackv1alpha1.AWSResourceName {
 	if ri.meta != nil {
 		return ri.meta.ARN
 	}
@@ -25,7 +25,7 @@ func (ri *{{ .CRD.Names.CamelLower }}ResourceIdentifiers) ARN() *ackv1alpha1.AWS
 // OwnerAccountID returns the AWS account identifier in which the
 // backend AWS resource resides, or nil if this information is not known
 // for the resource
-func (ri *{{ .CRD.Names.CamelLower }}ResourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
+func (ri *resourceIdentifiers) OwnerAccountID() *ackv1alpha1.AWSAccountID {
 	if ri.meta != nil {
 		return ri.meta.OwnerAccountID
 	}

--- a/templates/pkg/crd_manager_factory.go.tpl
+++ b/templates/pkg/crd_manager_factory.go.tpl
@@ -11,23 +11,23 @@ import (
 	svcresource "github.com/aws/aws-service-operator-k8s/services/{{ .ServiceAlias }}/pkg/resource"
 )
 
-// {{ .CRD.Names.CamelLower }}ResourceManagerFactory produces {{ .CRD.Names.CamelLower }}ResourceManager objects. It
-// implements the `types.AWSResourceManagerFactory` interface.
-type {{ .CRD.Names.CamelLower }}ResourceManagerFactory struct {
+// resourceManagerFactory produces resourceManager objects. It implements the
+// `types.AWSResourceManagerFactory` interface.
+type resourceManagerFactory struct {
 	sync.RWMutex
 	// rmCache contains resource managers for a particular AWS account ID
-	rmCache map[ackv1alpha1.AWSAccountID]*{{ .CRD.Names.CamelLower }}ResourceManager
+	rmCache map[ackv1alpha1.AWSAccountID]*resourceManager
 }
 
 // ResourcePrototype returns an AWSResource that resource managers produced by
 // this factory will handle
-func (f *{{ .CRD.Names.CamelLower }}ResourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
-	return &{{ .CRD.Names.CamelLower }}ResourceDescriptor{}
+func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescriptor {
+	return &resourceDescriptor{}
 }
 
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
-func (f *{{ .CRD.Names.CamelLower }}ResourceManagerFactory) ManagerFor(
+func (f *resourceManagerFactory) ManagerFor(
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -41,7 +41,7 @@ func (f *{{ .CRD.Names.CamelLower }}ResourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := new{{ .CRD.Kind }}ResourceManager(id)
+	rm, err := newResourceManager(id)
 	if err != nil {
 		return nil, err
 	}
@@ -49,12 +49,12 @@ func (f *{{ .CRD.Names.CamelLower }}ResourceManagerFactory) ManagerFor(
 	return rm, nil
 }
 
-func new{{ .CRD.Kind }}ResourceManagerFactory() *{{ .CRD.Names.CamelLower }}ResourceManagerFactory {
-	return &{{ .CRD.Names.CamelLower }}ResourceManagerFactory{
-		rmCache: map[ackv1alpha1.AWSAccountID]*{{ .CRD.Names.CamelLower }}ResourceManager{},
+func newResourceManagerFactory() *resourceManagerFactory {
+	return &resourceManagerFactory{
+		rmCache: map[ackv1alpha1.AWSAccountID]*resourceManager{},
 	}
 }
 
 func init() {
-	svcresource.RegisterManagerFactory(new{{ .CRD.Kind }}ResourceManagerFactory())
+	svcresource.RegisterManagerFactory(newResourceManagerFactory())
 }

--- a/templates/pkg/crd_resource.go.tpl
+++ b/templates/pkg/crd_resource.go.tpl
@@ -12,9 +12,9 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 )
 
-// {{ .CRD.Names.CamelLower }}Resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
+// resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`
 // interface
-type {{ .CRD.Names.CamelLower }}Resource struct {
+type resource struct {
 	// The Kubernetes-native CR representing the resource
 	ko *svcapitypes.{{ .CRD.Names.Camel }}
 	// The aws-sdk-go-native representation of the resource
@@ -24,36 +24,36 @@ type {{ .CRD.Names.CamelLower }}Resource struct {
 // Identifiers returns an AWSResourceIdentifiers object containing various
 // identifying information, including the AWS account ID that owns the
 // resource, the resource's AWS Resource Name (ARN)
-func (r *{{ .CRD.Names.CamelLower }}Resource) Identifiers() acktypes.AWSResourceIdentifiers {
-	return &{{ .CRD.Names.CamelLower }}ResourceIdentifiers{r.ko.Status.ACKResourceMetadata}
+func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
+	return &resourceIdentifiers{r.ko.Status.ACKResourceMetadata}
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
 // deletion timestemp
-func (r *{{ .CRD.Names.CamelLower }}Resource) IsBeingDeleted() bool {
+func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }
 
 // RuntimeObject returns the Kubernetes apimachinery/runtime representation of
 // the AWSResource
-func (r *{{ .CRD.Names.CamelLower }}Resource) RuntimeObject() k8srt.Object {
+func (r *resource) RuntimeObject() k8srt.Object {
 	return r.ko
 }
 
 // MetaObject returns the Kubernetes apimachinery/apis/meta/v1.Object
 // representation of the AWSResource
-func (r *{{ .CRD.Names.CamelLower }}Resource) MetaObject() metav1.Object {
+func (r *resource) MetaObject() metav1.Object {
 	return r.ko
 }
 
 // RuntimeMetaObject returns an object that implements both the Kubernetes
 // apimachinery/runtime.Object and the Kubernetes
 // apimachinery/apis/meta/v1.Object interfaces
-func (r *{{ .CRD.Names.CamelLower }}Resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
+func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 	return r.ko
 }
 
 // Conditions returns the ACK Conditions collection for the AWSResource
-func (r *{{ .CRD.Names.CamelLower }}Resource) Conditions() []*ackv1alpha1.Condition {
+func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }


### PR DESCRIPTION
Originally, I'd had the controller code generators outputting the
different resource managers, manager factories, identifiers and
descriptors into a single `services/$SERVICE/pkg/resource` package. This
is why the templates for generating those CRD-specific objects prefixed
each object with the CRD's Kind. For example, the Book's resource
manager struct was called bookResourceManager.

I switched the code generators to output each CRD into its own separate
Go package (e.g. `services/bookstore/pkg/resource/book`) but kept the
CRD name prefix on the structs defined in the package. This caused the
templates to be unnecessarily verbose and less readable.

With this patch, I've removed that CRD name prefix on the individual
resource package's structs, so every CRD's resource package has
identically-named structs: resource, resourceDescriptor,
resourceIdentifiers, resourceManager, and resourceManagerFactory.

Consistency and readability are key.

I've also removed the unused AWSResourceManager.Exists interface method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
