### PR TITLE
collate all Operations for a CRD from schema

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -21,7 +21,10 @@ import (
 )
 
 type CRDOps struct {
-	CreateOp *openapi3.Operation
+	Create  *openapi3.Operation
+	ReadOne *openapi3.Operation
+	Update  *openapi3.Operation
+	Delete  *openapi3.Operation
 }
 
 type CRD struct {
@@ -40,8 +43,8 @@ type CRD struct {
 
 func NewCRD(
 	names names.Names,
-	createOp *openapi3.Operation,
 	sdkObjType string,
+	crdOps CRDOps,
 ) *CRD {
 	pluralize := pluralize.NewClient()
 	kind := names.Camel
@@ -51,6 +54,6 @@ func NewCRD(
 		Kind:          kind,
 		Plural:        plural,
 		SDKObjectType: sdkObjType,
-		Ops:           CRDOps{createOp},
+		Ops:           crdOps,
 	}
 }

--- a/pkg/schema/crd.go
+++ b/pkg/schema/crd.go
@@ -14,11 +14,8 @@
 package schema
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/aws/aws-service-operator-k8s/pkg/model"
@@ -29,49 +26,26 @@ func (h *Helper) GetCRDs() ([]*model.CRD, error) {
 	if h.crds != nil {
 		return h.crds, nil
 	}
-	api := h.api
-	pluralize := pluralize.NewClient()
 	crds := []*model.CRD{}
 
-	// create an index of Operations by operation types
-	opTypeIndex := map[opType]map[string]*openapi3.Operation{}
-	for _, pathItem := range api.Paths {
-		if pathItem.Post != nil {
-			op := pathItem.Post
-			opID := op.OperationID
-			opType := getOpTypeFromOpID(opID)
-			if _, found := opTypeIndex[opType]; !found {
-				opTypeIndex[opType] = map[string]*openapi3.Operation{}
-			}
-			opTypeIndex[opType][opID] = op
-		}
-		if pathItem.Put != nil {
-			op := pathItem.Put
-			opID := op.OperationID
-			opType := getOpTypeFromOpID(opID)
-			if _, found := opTypeIndex[opType]; !found {
-				opTypeIndex[opType] = map[string]*openapi3.Operation{}
-			}
-			opTypeIndex[opType][opID] = op
-		}
-	}
+	opMap := h.GetOperationMap()
 
-	createOps := opTypeIndex[otCreate]
-	for opID, createOp := range createOps {
-		crdName := strings.TrimPrefix(opID, "Create")
-		singularName := pluralize.Singular(crdName)
-		pluralName := pluralize.Plural(crdName)
-		if pluralName == crdName {
-			// For now, ignore batch create operations since we're just trying
-			// to determine top-level singular crds
-			fmt.Printf("operation %s looks to be a batch create operation.\n", opID)
-			continue
-		}
+	createOps := (*opMap)[OpTypeCreate]
+	readOneOps := (*opMap)[OpTypeGet]
+	updateOps := (*opMap)[OpTypeUpdate]
+	deleteOps := (*opMap)[OpTypeDelete]
 
-		names := names.New(singularName)
+	for resName, createOp := range createOps {
+		names := names.New(resName)
 		sdkObjType := h.sdkObjectTypeFromOp(createOp)
-		crd := model.NewCRD(names, createOp, sdkObjType)
-		inAttrs, outAttrs, err := h.getAttrsFromOp(createOp, crdName)
+		crdOps := model.CRDOps{
+			Create:  createOps[resName],
+			ReadOne: readOneOps[resName],
+			Update:  updateOps[resName],
+			Delete:  deleteOps[resName],
+		}
+		crd := model.NewCRD(names, sdkObjType, crdOps)
+		inAttrs, outAttrs, err := h.getAttrsFromOp(createOp, resName)
 		if err != nil {
 			return nil, err
 		}
@@ -92,4 +66,25 @@ func (h *Helper) GetCRDs() ([]*model.CRD, error) {
 	})
 	h.crds = crds
 	return crds, nil
+}
+
+func (h *Helper) GetOperationMap() *OperationMap {
+	if h.opMap != nil {
+		return h.opMap
+	}
+	api := h.api
+	// create an index of Operations by operation types and resource name
+	opMap := OperationMap{}
+	for _, pathItem := range api.Paths {
+		for _, op := range pathItem.Operations() {
+			opID := op.OperationID
+			opType, resName := GetOpTypeAndResourceNameFromOpID(opID)
+			if _, found := opMap[opType]; !found {
+				opMap[opType] = map[string]*openapi3.Operation{}
+			}
+			opMap[opType][resName] = op
+		}
+	}
+	h.opMap = &opMap
+	return &opMap
 }

--- a/pkg/schema/crd_test.go
+++ b/pkg/schema/crd_test.go
@@ -65,4 +65,16 @@ func TestGetCRDs(t *testing.T) {
 		"TopicARN",
 	}
 	assert.Equal(expStatusAttrCamel, attrCamelNames(statusAttrs))
+
+	// The Topic API is a little weird. There are Create and Delete operations
+	// ("CreateTopic", "DeleteTopic") but there is no ReadOne operation (there
+	// is a "GetTopicAttributes" call though) or Update operation (there is a
+	// "SetTopicAttributes" call though)
+	require.NotNil(topicCRD.Ops)
+
+	assert.NotNil(topicCRD.Ops.Create)
+	assert.NotNil(topicCRD.Ops.Delete)
+
+	assert.Nil(topicCRD.Ops.ReadOne)
+	assert.Nil(topicCRD.Ops.Update)
 }

--- a/pkg/schema/helper.go
+++ b/pkg/schema/helper.go
@@ -27,6 +27,8 @@ type Helper struct {
 	api          *openapi3.Swagger
 	serviceAlias string
 	crds         []*model.CRD
+	// A map of operation type and resource name to openapi3.Operation
+	opMap *OperationMap
 }
 
 func (h *Helper) GetServiceAlias() string {
@@ -63,5 +65,5 @@ func (h *Helper) GetSchema(schemaName string) *openapi3.Schema {
 }
 
 func NewHelper(api *openapi3.Swagger) *Helper {
-	return &Helper{api, "", nil}
+	return &Helper{api, "", nil, nil}
 }

--- a/pkg/schema/op_test.go
+++ b/pkg/schema/op_test.go
@@ -1,0 +1,97 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-service-operator-k8s/pkg/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOpTypeAndResourceNameFromOpID(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		opID       string
+		expOpType  schema.OpType
+		expResName string
+	}{
+		{
+			"CreateTopic",
+			schema.OpTypeCreate,
+			"Topic",
+		},
+		{
+			"CreateOrUpdateTopic",
+			schema.OpTypeReplace,
+			"Topic",
+		},
+		{
+			"CreateBatchTopics",
+			schema.OpTypeCreateBatch,
+			"Topic",
+		},
+		{
+			"CreateBatchTopic",
+			schema.OpTypeCreateBatch,
+			"Topic",
+		},
+		{
+			"BatchCreateTopics",
+			schema.OpTypeCreateBatch,
+			"Topic",
+		},
+		{
+			"BatchCreateTopic",
+			schema.OpTypeCreateBatch,
+			"Topic",
+		},
+		{
+			"CreateTopics",
+			schema.OpTypeCreateBatch,
+			"Topic",
+		},
+		{
+			"DescribeEC2Instances",
+			schema.OpTypeList,
+			"EC2Instance",
+		},
+		{
+			"DescribeEC2Instance",
+			schema.OpTypeGet,
+			"EC2Instance",
+		},
+		{
+			"UpdateTopic",
+			schema.OpTypeUpdate,
+			"Topic",
+		},
+		{
+			"DeleteTopic",
+			schema.OpTypeDelete,
+			"Topic",
+		},
+		{
+			"PauseEC2Instance",
+			schema.OpTypeUnknown,
+			"",
+		},
+	}
+	for _, test := range tests {
+		ot, resName := schema.GetOpTypeAndResourceNameFromOpID(test.opID)
+		assert.Equal(test.expOpType, ot, test.opID)
+		assert.Equal(test.expResName, resName, test.opID)
+	}
+}


### PR DESCRIPTION
Following patches rely on being able to determine the payload of an
operation in order to generate the appropriate SDK-specific objects in
the AWSResourceManager templated code. This patch creates a map, keyed
by operation type (e.g. OpTypeCreate, OpTypeGet, etc) and resource name
(the Kind of the CRD) to an *openapi3.Operation struct that the
templates will use to query for payload information.

This patch also changes the resource manager implementation to split out service
SDK-specific HTTP request payload construction (for Create, Read, Update
and Delete APIs) into a separate helper method where we can isolate the
service-specific code better.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
