### PR TITLE
fix pluralized referred-to object types in arrays

### DIFF
--- a/pkg/schema/testdata/complex-types.yaml
+++ b/pkg/schema/testdata/complex-types.yaml
@@ -60,9 +60,24 @@ components:
     Base64:
       pattern: ^\S+$
       type: string
+    Boolean:
+      type: bool
     CreationTimestamp:
       format: date-time
       type: string
+    DBCluster:
+      properties:
+        DBClusterOptionGroupMemberships:
+          $ref: '#/components/schemas/DBClusterOptionGroupMemberships'
+    DBClusterOptionGroupMemberships:
+      items:
+        properties:
+          DBClusterOptionGroupName:
+            $ref: '#/components/schemas/String'
+          Status:
+            $ref: '#/components/schemas/String'
+        type: object
+      type: array
     DescribeImagesFilter:
       properties:
         tagStatus:
@@ -290,6 +305,46 @@ components:
       type: string
     NextToken:
       type: string
+    Option:
+      properties:
+        OptionName:
+          $ref: '#/components/schemas/String'
+      type: object
+    OptionGroup:
+      properties:
+        OptionGroupName:
+          $ref: '#/components/schemas/String'
+        Options:
+          $ref: '#/components/schemas/OptionsList'
+      type: object
+    OptionGroupOption:
+      properties:
+        OptionGroupOptionVersions:
+          $ref: '#/components/schemas/OptionGroupOptionVersionsList'
+      type: object
+    OptionGroupOptionVersionsList:
+      items:
+        properties:
+          IsDefault:
+            $ref: '#/components/schemas/Boolean'
+          Version:
+            $ref: '#/components/schemas/String'
+        type: object
+      type: array
+    OptionGroupsList:
+      items:
+        properties:
+          Options:
+            $ref: '#/components/schemas/OptionsList'
+        type: object
+      type: array
+    OptionsList:
+      items:
+        properties:
+          OptionName:
+            $ref: '#/components/schemas/String'
+        type: object
+      type: array
     PartSize:
       format: int64
       minimum: 0
@@ -371,6 +426,8 @@ components:
       format: int64
       minimum: 0
       type: integer
+    String:
+      type: string
     Tag:
       properties:
         Key:
@@ -405,18 +462,6 @@ components:
       properties:
         field:
           type: unknown
-      type: object
-    UnknownImageScanFindingList:
-      type: array
-      items:
-        type: object
-        properties:
-          field:
-            type: string
-    UnknownImageScanFindings:
-      properties:
-        findings:
-          $ref: '#/components/schemas/UnknownImageScanFindingList'
       type: object
     UploadId:
       pattern: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'

--- a/pkg/schema/util_test.go
+++ b/pkg/schema/util_test.go
@@ -78,6 +78,27 @@ func TestGoTypeFromSchemaRef(t *testing.T) {
 			nil,
 		},
 		{
+			"object array type for only-pluralized type name",
+			"DBCluster",
+			names.New("DBClusterOptionGroupMemberships"),
+			"[]*DBClusterOptionGroupMemberships",
+			nil,
+		},
+		{
+			"object array type for List-suffixed wrapper struct name with pluralized referred-to object type",
+			"OptionGroup",
+			names.New("Options"),
+			"[]*Option",
+			nil,
+		},
+		{
+			"object array type for List-suffixed wrapper struct name where there is no referred-to object type, pluralized or singular",
+			"OptionGroupOption",
+			names.New("OptionGroupOptionVersions"),
+			"AnonymousArrayObjectType",
+			nil,
+		},
+		{
 			"map[string]string type",
 			"AnyTag",
 			names.New("tags"),
@@ -91,19 +112,12 @@ func TestGoTypeFromSchemaRef(t *testing.T) {
 			"",
 			fmt.Errorf("failed to determine Go type. schema.Type was %s", "unknown"),
 		},
-		{
-			"unknown array items referred-to type",
-			"UnknownImageScanFindings",
-			names.New("findings"),
-			"",
-			fmt.Errorf("failed to find %s when looking up arrayTypeName %s", "UnknownImageScanFinding", "UnknownImageScanFindingList"),
-		},
 	}
 	for _, test := range tests {
 		sh := testutil.NewSchemaHelperFromFile(t, "complex-types.yaml")
 
 		schema := sh.GetSchema(test.schemaName)
-		require.NotNil(schema)
+		require.NotNil(schema, test.name)
 
 		propSchemaRef := schema.Properties[test.propNames.Original]
 		require.NotNil(propSchemaRef, test.name)
@@ -111,10 +125,10 @@ func TestGoTypeFromSchemaRef(t *testing.T) {
 		gt, err := sh.GetGoTypeFromSchemaRef(test.propNames, propSchemaRef)
 		if test.expErr != nil {
 			assert.Error(err)
-			assert.Equal(test.expErr, err)
+			assert.Equal(test.expErr, err, test.name)
 		} else {
 			assert.Nil(err, "expected err to be nil but got %s", err)
 		}
-		assert.Equal(test.expGoType, gt)
+		assert.Equal(test.expGoType, gt, test.name)
 	}
 }


### PR DESCRIPTION
The RDS API's DBCluster resource has a schema that looks like this:

```yaml
    DBCluster:
      properties:
        ... lots of other fields ...
        DBClusterOptionGroupMemberships:
          $ref: '#/components/schemas/DBClusterOptionGroupMemberships'
    DBClusterOptionGroupMemberships:
      items:
        properties:
          DBClusterOptionGroupName:
            $ref: '#/components/schemas/String'
          Status:
            $ref: '#/components/schemas/String'
        type: object
      type: array
```

Note that there is no "DBClusterOptionGroupMembership" struct.

Many AWS APIs needlessly (due to XML legacy) wrap arrays of some
singular object in structs that are nothing more than a struct with a
single field that is an array of the singular object type. There is code
in ACK that looks for this situation and "unwraps" those needless
wrapper structs and makes the end Go type in the CRD's Spec struct a
slice of pointer to the singular object type.

So, instead of generating this:

```go
type MyField struct {
    Foo string
}
type MyFieldList struct {
    Foos []*Foo
}
type MyResourceSpec struct {
    Foos *MyFieldList
}
```

we generate the (much simpler and readable):

```go
type MyField struct {
    Foo string
}
type MyResourceSpec struct {
    Foos []*Foo
}
```

The code that looks at the above array-of-object-type fields and deduces
that the Go type for the `DBCluster.Spec.DBClusterOptionGroupName` field
was attempting to look for a schema with a singular version of the
"DBClusterOptionGroupMemberships" name. But there isn't one.

This patch fixes that situation and falls back to looking up the
pluralized version of the original array type name.

Fixes Issue #76 however we still need to figure out how to handle cases
where an "anonymous array element struct" is found. This occurs in, for
example, again in the RDS API, the following schema:
    
```yaml
    OptionGroupOptionVersionsList:
      items:
        properties:
          IsDefault:
            $ref: '#/components/schemas/Boolean'
          Version:
            $ref: '#/components/schemas/String'
        type: object
      type: array
    OptionGroupOptionsList:
      items:
        properties:
... lots of other fields ....
          OptionGroupOptionVersions:
            $ref: '#/components/schemas/OptionGroupOptionVersionsList'
        type: object
      type: array
```

There is no "OptionGroupOptionVersion" schema, nor is there an
"OptionGroupOptionVersions" schema. Instead, there is only an
"OptionGroupOptionVersionsList" schema that is itself an array type
containing an unnamed (anonymous) object element type containing two
properties "IsDefault" and "Version". :(

(Also note that there is actually an "OptionVersion" named
schema/struct! For some reason, the RDS API authors have the
OptionVersionsList struct contain elements of type "OptionVersion", but
the "OptionGroupOptionVersionsList" struct is different for some unknown
reason...)

Since there is no way for us to handle this in the current code, I just
return an error back up from the deduceArrayOfObjectsType() function and
let the Go type for the field just be "AnonymousArrayObjectType".
Clearly that will need to be addressed in the future but for now, it
gets the api/typedef generation working again for APIs like RDS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.